### PR TITLE
remove deps on libffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["The pivot-lang Authors"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm14-0", "no-libffi-linking"] }
 indexmap = "1.9.2"
 lazy_static = "1.4.0"
 paste = "1.0"


### PR DESCRIPTION
Fixes #29. 
不知道为啥之前移除后就无法编译，现在可以了，可能是因为用不稳定版本的inkwell的原因