### PR TITLE
fix: catch err when missing space

### DIFF
--- a/src/nomparser/array.rs
+++ b/src/nomparser/array.rs
@@ -21,12 +21,12 @@ use super::*;
 pub fn array_init(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         tuple((
-            tag_token(TokenType::LBRACKET),
+            tag_token_symbol(TokenType::LBRACKET),
             separated_list0(
-                tag_token(TokenType::COMMA),
+                tag_token_symbol(TokenType::COMMA),
                 del_newline_or_space!(logic_exp),
             ),
-            tag_token(TokenType::RBRACKET),
+            tag_token_symbol(TokenType::RBRACKET),
         )),
         |((_, lb), exps, (_, rb))| {
             let range = lb.start.to(rb.end);
@@ -41,9 +41,9 @@ pub fn array_init(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn array_element_op(input: Span) -> IResult<Span, (ComplexOp, Vec<Box<NodeEnum>>)> {
     delspace(map_res(
         tuple((
-            tag_token(TokenType::LBRACKET),
+            tag_token_symbol(TokenType::LBRACKET),
             opt(logic_exp),
-            tag_token(TokenType::RBRACKET),
+            tag_token_symbol(TokenType::RBRACKET),
             many0(comment),
         )),
         |(_, idx, (_, rr), com)| {

--- a/src/nomparser/array.rs
+++ b/src/nomparser/array.rs
@@ -1,5 +1,6 @@
 use std::fmt::Error;
 
+use internal_macro::test_parser;
 use nom::{
     branch::alt,
     bytes::complete::tag,
@@ -18,6 +19,14 @@ use crate::{
 
 use super::*;
 
+#[test_parser("[1,2,3]")]
+#[test_parser(
+    "[
+        1,
+        2,
+        x
+    ]"
+)]
 pub fn array_init(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         tuple((
@@ -35,6 +44,7 @@ pub fn array_init(input: Span) -> IResult<Span, Box<NodeEnum>> {
     )(input)
 }
 
+#[test_parser("[123]")]
 /// ```ebnf
 /// array_element_op = ('[' logic_exp ']') ;
 /// ```

--- a/src/nomparser/comment.rs
+++ b/src/nomparser/comment.rs
@@ -1,5 +1,6 @@
 use crate::nomparser::Span;
 use crate::{ast::node::comment::CommentNode, ast::range::Range};
+use internal_macro::{test_parser, test_parser_error};
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_until},
@@ -11,6 +12,9 @@ use nom_locate::LocatedSpan;
 
 use super::*;
 
+#[test_parser("//123")]
+#[test_parser("/// 123\n")]
+#[test_parser_error("/ / 123\n")]
 pub fn comment(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         pair(

--- a/src/nomparser/constval.rs
+++ b/src/nomparser/constval.rs
@@ -57,6 +57,10 @@ pub fn bool_const(input: Span) -> IResult<Span, Box<NodeEnum>> {
     ))(input)
 }
 
+#[test_parser("123")]
+#[test_parser("12_3")]
+#[test_parser("1_2_3")]
+#[test_parser_error("1 23")]
 fn decimal(input: Span) -> IResult<Span, Span> {
     recognize(many1(terminated(one_of("0123456789"), many0(char('_')))))(input)
 }

--- a/src/nomparser/constval.rs
+++ b/src/nomparser/constval.rs
@@ -36,16 +36,16 @@ pub fn number(input: Span) -> IResult<Span, Box<NodeEnum>> {
     Ok((re, Box::new(node.into())))
 }
 
-#[test_parser("true")]
+#[test_parser(" true")]
 #[test_parser("false")]
 #[test_parser_error("tru")]
 #[test_parser_error("fales")]
 pub fn bool_const(input: Span) -> IResult<Span, Box<NodeEnum>> {
     alt((
-        map_res(tag_token(TokenType::TRUE), |(_, range)| {
+        map_res(tag_token_word(TokenType::TRUE), |(_, range)| {
             res_enum(BoolConstNode { value: true, range }.into())
         }),
-        map_res(tag_token(TokenType::FALSE), |(_, range)| {
+        map_res(tag_token_word(TokenType::FALSE), |(_, range)| {
             res_enum(
                 BoolConstNode {
                     value: false,
@@ -70,8 +70,8 @@ fn float(input: Span) -> IResult<Span, Span> {
             opt(tuple((
                 one_of("eE"),
                 opt(alt((
-                    tag_token(TokenType::PLUS),
-                    tag_token(TokenType::MINUS),
+                    tag_token_symbol(TokenType::PLUS),
+                    tag_token_symbol(TokenType::MINUS),
                 ))),
                 decimal,
             ))),
@@ -81,8 +81,8 @@ fn float(input: Span) -> IResult<Span, Span> {
             opt(preceded(char('.'), decimal)),
             one_of("eE"),
             opt(alt((
-                tag_token(TokenType::PLUS),
-                tag_token(TokenType::MINUS),
+                tag_token_symbol(TokenType::PLUS),
+                tag_token_symbol(TokenType::MINUS),
             ))),
             decimal,
         ))), // Case three: 42. and 42.42

--- a/src/nomparser/control.rs
+++ b/src/nomparser/control.rs
@@ -45,6 +45,13 @@ use super::*;
     return;
 }"#
 )]
+#[test_parser_error(
+    "ifa > 1 { 
+    a = 1;
+} else {
+    a = 2;
+}"
+)]
 /// ```ebnf
 /// if_statement = "if" logic_exp statement_block ("else" (if_statement | statement_block))? ;
 /// ```
@@ -94,6 +101,12 @@ pub fn if_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 )]
 #[test_parser(
     "while true {
+    let a = b;
+}
+"
+)]
+#[test_parser_error(
+    "whiletrue {
     let a = b;
 }
 "
@@ -159,7 +172,16 @@ pub fn while_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
                 
     }"
 )]
-
+#[test_parser_error(
+    "forlet i = 0; i < 5; i = i + 1{
+                
+    }"
+)]
+#[test_parser_error(
+    "for leti = 0; i < 5; i = i + 1{
+                
+    }"
+)]
 /// ```enbf
 /// for_statement = "for" (assignment | new_variable) ";" logic_exp ";" assignment statement_block;
 /// ```

--- a/src/nomparser/control.rs
+++ b/src/nomparser/control.rs
@@ -177,11 +177,6 @@ pub fn while_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
                 
     }"
 )]
-#[test_parser_error(
-    "for leti = 0; i < 5; i = i + 1{
-                
-    }"
-)]
 /// ```enbf
 /// for_statement = "for" (assignment | new_variable) ";" logic_exp ";" assignment statement_block;
 /// ```

--- a/src/nomparser/control.rs
+++ b/src/nomparser/control.rs
@@ -51,12 +51,12 @@ use super::*;
 pub fn if_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         delspace(tuple((
-            tag_token(TokenType::IF),
+            tag_token_word(TokenType::IF),
             parse_with_ex(logic_exp, true),
             statement_block,
             opt(delspace(comment)),
             opt(preceded(
-                tag_token(TokenType::ELSE),
+                tag_token_word(TokenType::ELSE),
                 alt((
                     if_statement,
                     map_res(statement_block, |n| res_enum(n.into())),
@@ -104,7 +104,7 @@ pub fn if_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn while_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         delspace(tuple((
-            tag_token(TokenType::WHILE),
+            tag_token_word(TokenType::WHILE),
             alt_except(
                 logic_exp,
                 "{",
@@ -166,11 +166,11 @@ pub fn while_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn for_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         delspace(tuple((
-            tag_token(TokenType::FOR),
+            tag_token_word(TokenType::FOR),
             opt(alt((assignment, new_variable))),
-            tag_token(TokenType::SEMI),
+            tag_token_symbol(TokenType::SEMI),
             logic_exp,
-            tag_token(TokenType::SEMI),
+            tag_token_symbol(TokenType::SEMI),
             opt(assignment),
             statement_block,
             opt(delspace(comment)),
@@ -204,8 +204,8 @@ pub fn for_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn break_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         tuple((
-            tag_token(TokenType::BREAK),
-            tag_token(TokenType::SEMI),
+            tag_token_word(TokenType::BREAK),
+            tag_token_symbol(TokenType::SEMI),
             opt(delspace(comment)),
         )),
         |(_, _, optcomment)| {
@@ -228,8 +228,8 @@ pub fn break_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn continue_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         tuple((
-            tag_token(TokenType::CONTINUE),
-            tag_token(TokenType::SEMI),
+            tag_token_word(TokenType::CONTINUE),
+            tag_token_symbol(TokenType::SEMI),
             opt(delspace(comment)),
         )),
         |(_, _, optcomment)| {

--- a/src/nomparser/expression.rs
+++ b/src/nomparser/expression.rs
@@ -56,7 +56,10 @@ fn unary_exp(input: Span) -> IResult<Span, Box<NodeEnum>> {
         pointer_exp,
         map_res(
             tuple((
-                alt((tag_token(TokenType::MINUS), tag_token(TokenType::NOT))),
+                alt((
+                    tag_token_symbol(TokenType::MINUS),
+                    tag_token_symbol(TokenType::NOT),
+                )),
                 pointer_exp,
             )),
             |((op, op_range), exp)| {
@@ -83,8 +86,8 @@ pub fn pointer_exp(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         delspace(pair(
             many0(alt((
-                tag_token(TokenType::TAKE_PTR),
-                tag_token(TokenType::TAKE_VAL),
+                tag_token_symbol(TokenType::TAKE_PTR),
+                tag_token_symbol(TokenType::TAKE_VAL),
             ))),
             complex_exp,
         )),
@@ -221,7 +224,7 @@ fn primary_exp(input: Span) -> IResult<Span, Box<NodeEnum>> {
 fn take_exp_op(input: Span) -> IResult<Span, (ComplexOp, Vec<Box<NodeEnum>>)> {
     delspace(map_res(
         preceded(
-            tag_token(TokenType::DOT),
+            tag_token_symbol(TokenType::DOT),
             pair(opt(identifier), many0(comment)),
         ),
         |(idx, coms)| Ok::<_, Error>((ComplexOp::FieldOp(idx), coms)),
@@ -236,9 +239,9 @@ fn take_exp_op(input: Span) -> IResult<Span, (ComplexOp, Vec<Box<NodeEnum>>)> {
 fn parantheses_exp(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         delimited(
-            tag_token(TokenType::LPAREN),
+            tag_token_symbol(TokenType::LPAREN),
             parse_with_ex(logic_exp, false),
-            tag_token(TokenType::RPAREN),
+            tag_token_symbol(TokenType::RPAREN),
         ),
         |exp| {
             res_enum(

--- a/src/nomparser/function.rs
+++ b/src/nomparser/function.rs
@@ -48,21 +48,21 @@ pub fn function_def(input: Span) -> IResult<Span, Box<TopLevel>> {
     map_res(
         tuple((
             many0(del_newline_or_space!(comment)),
-            tag_token(TokenType::FN),
+            tag_token_word(TokenType::FN),
             identifier,
             opt(generic_type_def),
-            tag_token(TokenType::LPAREN),
+            tag_token_symbol(TokenType::LPAREN),
             del_newline_or_space!(separated_list0(
-                tag_token(TokenType::COMMA),
+                tag_token_symbol(TokenType::COMMA),
                 del_newline_or_space!(typed_identifier),
             )),
-            tag_token(TokenType::RPAREN),
+            tag_token_symbol(TokenType::RPAREN),
             type_name,
             alt((
                 map_res(statement_block, |b| {
                     Ok::<_, Error>((Some(b.clone()), b.range))
                 }),
-                map_res(tag_token(TokenType::SEMI), |(_, range)| {
+                map_res(tag_token_symbol(TokenType::SEMI), |(_, range)| {
                     Ok::<_, Error>((None, range))
                 }),
             )),
@@ -104,12 +104,12 @@ pub fn call_function_op(input: Span) -> IResult<Span, (ComplexOp, Vec<Box<NodeEn
     delspace(map_res(
         tuple((
             opt(generic_param_def),
-            tag_token(TokenType::LPAREN),
+            tag_token_symbol(TokenType::LPAREN),
             del_newline_or_space!(separated_list0(
-                tag_token(TokenType::COMMA),
+                tag_token_symbol(TokenType::COMMA),
                 del_newline_or_space!(logic_exp)
             )),
-            tag_token(TokenType::RPAREN),
+            tag_token_symbol(TokenType::RPAREN),
             many0(comment),
         )),
         |(generic, (_, st), paras, (_, end), com)| {

--- a/src/nomparser/function.rs
+++ b/src/nomparser/function.rs
@@ -12,7 +12,7 @@ use nom::{
 use crate::nomparser::Span;
 use crate::{ast::node::function::FuncDefNode, ast::tokens::TokenType};
 
-use internal_macro::test_parser;
+use internal_macro::{test_parser, test_parser_error};
 
 use super::*;
 
@@ -44,6 +44,7 @@ use super::*;
     "
 )]
 #[test_parser("fn f( \n) int;")]
+#[test_parser_error("fnf( \n) int;")]
 pub fn function_def(input: Span) -> IResult<Span, Box<TopLevel>> {
     map_res(
         tuple((

--- a/src/nomparser/helper.rs
+++ b/src/nomparser/helper.rs
@@ -2,6 +2,8 @@ use std::fmt::Error;
 
 use crate::nomparser::Span;
 use crate::{ast::range::Range, ast::tokens::TokenType};
+use nom::character::is_alphanumeric;
+use nom::sequence::preceded;
 use nom::{
     bytes::complete::tag, character::complete::space0, combinator::map_res, error::ParseError,
     sequence::delimited, AsChar, IResult, InputTake, InputTakeAtPosition, Parser,
@@ -9,12 +11,27 @@ use nom::{
 
 use super::*;
 
-pub fn tag_token(token: TokenType) -> impl Fn(Span) -> IResult<Span, (TokenType, Range)> {
+pub fn tag_token_symbol(token: TokenType) -> impl Fn(Span) -> IResult<Span, (TokenType, Range)> {
     move |input| {
         map_res(delspace(tag(token.get_str())), |_out: Span| {
             let end = _out.take_split(token.get_str().len()).0;
             Ok::<(TokenType, Range), Error>((token, Range::new(_out, end)))
         })(input)
+    }
+}
+pub fn tag_token_word(token: TokenType) -> impl Fn(Span) -> IResult<Span, (TokenType, Range)> {
+    move |input| {
+        let (s1, s2): (LocatedSpan<&str, bool>, LocatedSpan<&str, bool>) =
+            preceded(space0, tag(token.get_str()))(input)?;
+        if s1.starts_with(|c: char| is_alphanumeric(c as u8) || c == '_') {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                s2,
+                nom::error::ErrorKind::Tag,
+            )));
+        } else {
+            let end = s2.take_split(token.get_str().len()).0;
+            return Ok((s1, (token, Range::new(s2, end))));
+        }
     }
 }
 pub fn delspace<I, O, E, G>(parser: G) -> impl FnMut(I) -> IResult<I, O, E>

--- a/src/nomparser/helper.rs
+++ b/src/nomparser/helper.rs
@@ -19,6 +19,8 @@ pub fn tag_token_symbol(token: TokenType) -> impl Fn(Span) -> IResult<Span, (Tok
         })(input)
     }
 }
+
+/// 不能直接接 `字母`、`数字` 或 `_`，用于关键字
 pub fn tag_token_word(token: TokenType) -> impl Fn(Span) -> IResult<Span, (TokenType, Range)> {
     move |input| {
         let (s1, s2): (LocatedSpan<&str, bool>, LocatedSpan<&str, bool>) =

--- a/src/nomparser/identifier.rs
+++ b/src/nomparser/identifier.rs
@@ -37,9 +37,12 @@ use super::*;
 pub fn extern_identifier(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((
-            separated_list1(tag_token(TokenType::DOUBLE_COLON), delspace(identifier)),
-            opt(tag_token(TokenType::DOUBLE_COLON)), // 容忍未写完的语句
-            opt(tag_token(TokenType::COLON)),        // 容忍未写完的语句
+            separated_list1(
+                tag_token_symbol(TokenType::DOUBLE_COLON),
+                delspace(identifier),
+            ),
+            opt(tag_token_symbol(TokenType::DOUBLE_COLON)), // 容忍未写完的语句
+            opt(tag_token_symbol(TokenType::COLON)),        // 容忍未写完的语句
         )),
         |(mut ns, opt, opt2)| {
             let id = ns.pop().unwrap();
@@ -88,7 +91,7 @@ pub fn typed_identifier(input: Span) -> IResult<Span, Box<TypedIdentifierNode>> 
     delspace(map_res(
         tuple((
             identifier,
-            tag_token(TokenType::COLON),
+            tag_token_symbol(TokenType::COLON),
             opt(type_name),
             opt(comment),
         )),

--- a/src/nomparser/implement.rs
+++ b/src/nomparser/implement.rs
@@ -8,7 +8,7 @@ use nom::{
     IResult,
 };
 
-use internal_macro::test_parser;
+use internal_macro::{test_parser, test_parser_error};
 
 use super::*;
 
@@ -42,6 +42,14 @@ use super::*;
             return 0;
         }
         fn f2(x: int) int {
+            x = x+1;
+            return 0;
+        }
+    }"
+)]
+#[test_parser_error(
+    "impla::b::c {
+        fn f(x: int) int {
             x = x+1;
             return 0;
         }

--- a/src/nomparser/implement.rs
+++ b/src/nomparser/implement.rs
@@ -50,13 +50,13 @@ use super::*;
 pub fn impl_def(input: Span) -> IResult<Span, Box<TopLevel>> {
     map_res(
         tuple((
-            tag_token(TokenType::IMPL),
-            opt(pair(type_name, tag_token(TokenType::FOR))),
+            tag_token_word(TokenType::IMPL),
+            opt(pair(type_name, tag_token_word(TokenType::FOR))),
             type_name,
-            del_newline_or_space!(tag_token(TokenType::LBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::LBRACE)),
             many0(del_newline_or_space!(function_def)),
             many0(comment),
-            del_newline_or_space!(tag_token(TokenType::RBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::RBRACE)),
         )),
         |(_, o, tp, (_, start), func_def, comment0, (_, end))| {
             res_box(Box::new(TopLevel::ImplDef(ImplNode {

--- a/src/nomparser/macros.rs
+++ b/src/nomparser/macros.rs
@@ -16,7 +16,7 @@ macro_rules! parse_bin_ops {
                 many0(tuple((
                     alt((
                         $(
-                            tag_token(TokenType::$op),
+                            tag_token_symbol(TokenType::$op),
                         )*
                     )),
                     $exp,
@@ -35,7 +35,7 @@ macro_rules! parse_bin_ops {
 /// 所有分号结尾的statement都应该使用这个宏来处理分号
 macro_rules! semi_statement {
     ($e:expr) => {
-        alt((terminated($e, tag_token(TokenType::SEMI)), map_res(tuple(($e,recognize(many0(alt((tag("\n"), tag("\r\n"), preceded(many0(tag(" ")),tag("\n")), tag("\t"))))))), |(node,e)|{
+        alt((terminated($e, tag_token_symbol(TokenType::SEMI)), map_res(tuple(($e,recognize(many0(alt((tag("\n"), tag("\r\n"), preceded(many0(tag(" ")),tag("\n")), tag("\t"))))))), |(node,e)|{
             let range = node.range();
             let r = Range::new(e,e);
             res_enum(StErrorNode{

--- a/src/nomparser/pkg.rs
+++ b/src/nomparser/pkg.rs
@@ -7,7 +7,7 @@ use nom::{
 
 use crate::nomparser::Span;
 use crate::{ast::node::pkg::UseNode, ast::tokens::TokenType};
-use internal_macro::test_parser;
+use internal_macro::{test_parser, test_parser_error};
 
 use super::*;
 
@@ -18,6 +18,8 @@ use super::*;
 #[test_parser("use a::")]
 #[test_parser("use a")]
 #[test_parser("use a:")]
+#[test_parser_error("usea")]
+#[test_parser_error("usea:")]
 pub fn use_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         preceded(

--- a/src/nomparser/pkg.rs
+++ b/src/nomparser/pkg.rs
@@ -21,11 +21,11 @@ use super::*;
 pub fn use_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         preceded(
-            tag_token(TokenType::USE),
+            tag_token_word(TokenType::USE),
             delspace(tuple((
-                separated_list1(tag_token(TokenType::DOUBLE_COLON), identifier),
-                opt(tag_token(TokenType::DOUBLE_COLON)),
-                opt(tag_token(TokenType::COLON)),
+                separated_list1(tag_token_symbol(TokenType::DOUBLE_COLON), identifier),
+                opt(tag_token_symbol(TokenType::DOUBLE_COLON)),
+                opt(tag_token_symbol(TokenType::COLON)),
             ))),
         ),
         |(ns, opt, opt2)| {

--- a/src/nomparser/statement.rs
+++ b/src/nomparser/statement.rs
@@ -24,7 +24,7 @@ use internal_macro::{test_parser, test_parser_error};
 use std::fmt::Error;
 
 use super::*;
-
+#[test_parser(";")]
 fn empty_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         preceded(tag_token_symbol(TokenType::SEMI), opt(delspace(comment))),
@@ -104,6 +104,7 @@ fn statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 }
 
 #[test_parser("let a = 1")]
+#[test_parser_error("leta = 1")]
 pub fn new_variable(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((
@@ -161,6 +162,8 @@ pub fn assignment(input: Span) -> IResult<Span, Box<NodeEnum>> {
 #[test_parser("return;")]
 #[test_parser("return a;")]
 #[test_parser("return 1 + 2;")]
+#[test_parser_error("returntrue;")]
+#[test_parser_error("return1 + 2;")]
 #[test_parser_error("return a = 2;")]
 // ```
 // return_statement = "return" logic_exp newline ;
@@ -204,6 +207,7 @@ fn return_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 }
 
 #[test_parser("const a = 1")]
+#[test_parser_error("consta = 1")]
 pub fn global_variable(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((

--- a/src/nomparser/statement.rs
+++ b/src/nomparser/statement.rs
@@ -27,7 +27,7 @@ use super::*;
 
 fn empty_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
-        preceded(tag_token(TokenType::SEMI), opt(delspace(comment))),
+        preceded(tag_token_symbol(TokenType::SEMI), opt(delspace(comment))),
         |optcomment| {
             let comments = if let Some(com) = optcomment {
                 vec![vec![com]]
@@ -55,9 +55,9 @@ fn empty_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn statement_block(input: Span) -> IResult<Span, StatementsNode> {
     delspace(map_res(
         tuple((
-            del_newline_or_space!(tag_token(TokenType::LBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::LBRACE)),
             many0(del_newline_or_space!(statement)),
-            del_newline_or_space!(tag_token(TokenType::RBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::RBRACE)),
         )),
         |((_, start), v, (_, end))| {
             let range = start.start.to(end.end);
@@ -107,10 +107,10 @@ fn statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn new_variable(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((
-            tag_token(TokenType::LET),
+            tag_token_word(TokenType::LET),
             identifier,
-            opt(pair(tag_token(TokenType::COLON), type_name)),
-            opt(pair(tag_token(TokenType::ASSIGN), logic_exp)),
+            opt(pair(tag_token_symbol(TokenType::COLON), type_name)),
+            opt(pair(tag_token_symbol(TokenType::ASSIGN), logic_exp)),
         )),
         |((_, start), a, tp, v)| {
             let mut end = a.range.end;
@@ -140,7 +140,7 @@ pub fn new_variable(input: Span) -> IResult<Span, Box<NodeEnum>> {
 #[test_parser("a = 1")]
 pub fn assignment(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
-        tuple((pointer_exp, tag_token(TokenType::ASSIGN), logic_exp)),
+        tuple((pointer_exp, tag_token_symbol(TokenType::ASSIGN), logic_exp)),
         |(left, _op, right)| {
             let range = left.range().start.to(right.range().end);
             res_enum(
@@ -168,9 +168,9 @@ pub fn assignment(input: Span) -> IResult<Span, Box<NodeEnum>> {
 fn return_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((
-            tag_token(TokenType::RETURN),
+            tag_token_word(TokenType::RETURN),
             opt(logic_exp),
-            tag_token(TokenType::SEMI),
+            tag_token_symbol(TokenType::SEMI),
             opt(delspace(comment)),
         )),
         |((_, range), val, _, optcomment)| {
@@ -207,9 +207,9 @@ fn return_statement(input: Span) -> IResult<Span, Box<NodeEnum>> {
 pub fn global_variable(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((
-            tag_token(TokenType::CONST),
+            tag_token_word(TokenType::CONST),
             identifier,
-            tag_token(TokenType::ASSIGN),
+            tag_token_symbol(TokenType::ASSIGN),
             logic_exp,
         )),
         |(_, var, _, exp)| {

--- a/src/nomparser/string_literal.rs
+++ b/src/nomparser/string_literal.rs
@@ -165,9 +165,9 @@ where
 pub fn string_literal(input: Span) -> IResult<Span, Box<NodeEnum>> {
     map_res(
         tuple((
-            tag_token(TokenType::DOUBLE_QUOTE),
+            tag_token_symbol(TokenType::DOUBLE_QUOTE),
             parse_string_content,
-            tag_token(TokenType::DOUBLE_QUOTE),
+            tag_token_symbol(TokenType::DOUBLE_QUOTE),
         )),
         |((_, st), s, (_, end))| {
             res_enum(

--- a/src/nomparser/structure.rs
+++ b/src/nomparser/structure.rs
@@ -6,7 +6,7 @@ use crate::{
     ast::node::{types::StructInitNode, NodeEnum, RangeTrait},
     ast::{node::types::StructInitFieldNode, tokens::TokenType},
 };
-use internal_macro::test_parser;
+use internal_macro::{test_parser, test_parser_error};
 use nom::{
     branch::alt,
     bytes::complete::tag,
@@ -21,6 +21,12 @@ use super::*;
 
 #[test_parser(
     "struct mystruct<A|B|C> {
+    myname: int;//123
+    myname2: int;
+}"
+)]
+#[test_parser_error(
+    "structmystruct<A|B|C> {
     myname: int;//123
     myname2: int;
 }"

--- a/src/nomparser/structure.rs
+++ b/src/nomparser/structure.rs
@@ -29,16 +29,16 @@ pub fn struct_def(input: Span) -> IResult<Span, Box<TopLevel>> {
     map_res(
         tuple((
             many0(del_newline_or_space!(comment)),
-            tag_token(TokenType::STRUCT),
+            tag_token_word(TokenType::STRUCT),
             identifier,
             opt(generic_type_def),
-            del_newline_or_space!(tag_token(TokenType::LBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::LBRACE)),
             many0(tuple((
                 del_newline_or_space!(typed_identifier),
-                opt(tag_token(TokenType::SEMI)),
+                opt(tag_token_symbol(TokenType::SEMI)),
                 opt(comment),
             ))),
-            del_newline_or_space!(tag_token(TokenType::RBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::RBRACE)),
         )),
         |(doc, (_, start), id, generics, _, fields, (_, end))| {
             let range = start.start.to(end.end);
@@ -81,7 +81,7 @@ pub fn struct_def(input: Span) -> IResult<Span, Box<TopLevel>> {
 /// special: del newline or space
 fn struct_init_field(input: Span) -> IResult<Span, Box<StructInitFieldNode>> {
     del_newline_or_space!(map_res(
-        tuple((identifier, tag_token(TokenType::COLON), logic_exp,)),
+        tuple((identifier, tag_token_symbol(TokenType::COLON), logic_exp,)),
         |(id, _, exp)| {
             let range = id.range.start.to(exp.range().end);
             Ok::<_, Error>(Box::new(StructInitFieldNode {
@@ -111,14 +111,14 @@ pub fn struct_init(input: Span) -> IResult<Span, Box<NodeEnum>> {
         tuple((
             type_name,
             opt(generic_param_def),
-            del_newline_or_space!(tag_token(TokenType::LBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::LBRACE)),
             alt((
                 map_res(
                     pair(
                         many0(tuple((
                             terminated(
                                 del_newline_or_space!(struct_init_field),
-                                tag_token(TokenType::COMMA),
+                                tag_token_symbol(TokenType::COMMA),
                             ),
                             many0(comment),
                         ))),
@@ -144,7 +144,7 @@ pub fn struct_init(input: Span) -> IResult<Span, Box<NodeEnum>> {
                 }),
             )),
             many0(comment),
-            del_newline_or_space!(tag_token(TokenType::RBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::RBRACE)),
         )),
         |(name, generic_params, _, (fields, lcomment), rcomment, _)| {
             let range = if fields.len() > 0 {

--- a/src/nomparser/types.rs
+++ b/src/nomparser/types.rs
@@ -11,7 +11,7 @@ use crate::{
         tokens::TokenType,
     },
 };
-use internal_macro::test_parser;
+use internal_macro::{test_parser, test_parser_error};
 use nom::{
     branch::alt,
     bytes::complete::tag,
@@ -142,6 +142,11 @@ pub fn generic_param_def(input: Span) -> IResult<Span, Box<GenericParamNode>> {
 /// ```
 #[test_parser(
     "trait mytrait<A|B|C> {
+    fn a() A;
+}"
+)]
+#[test_parser_error(
+    "traitmytrait<A|B|C> {
     fn a() A;
 }"
 )]

--- a/src/nomparser/types.rs
+++ b/src/nomparser/types.rs
@@ -26,7 +26,7 @@ use super::*;
 pub fn type_name(input: Span) -> IResult<Span, Box<TypeNodeEnum>> {
     delspace(map_res(
         pair(
-            many0(tag_token(TokenType::TAKE_VAL)),
+            many0(tag_token_symbol(TokenType::TAKE_VAL)),
             alt((basic_type, array_type)),
         ),
         |(pts, n)| {
@@ -66,11 +66,11 @@ fn basic_type(input: Span) -> IResult<Span, Box<TypeNodeEnum>> {
 fn array_type(input: Span) -> IResult<Span, Box<TypeNodeEnum>> {
     map_res(
         tuple((
-            tag_token(TokenType::LBRACKET),
+            tag_token_symbol(TokenType::LBRACKET),
             type_name,
-            tag_token(TokenType::MUL),
+            tag_token_symbol(TokenType::MUL),
             number,
-            tag_token(TokenType::RBRACKET),
+            tag_token_symbol(TokenType::RBRACKET),
         )),
         |(_, tp, _, size, _)| {
             let range = size.range().start.to(tp.range().end);
@@ -94,9 +94,9 @@ fn array_type(input: Span) -> IResult<Span, Box<TypeNodeEnum>> {
 pub fn generic_type_def(input: Span) -> IResult<Span, Box<GenericDefNode>> {
     map_res(
         tuple((
-            tag_token(TokenType::LESS),
-            separated_list1(tag_token(TokenType::GENERIC_SEP), identifier),
-            tag_token(TokenType::GREATER),
+            tag_token_symbol(TokenType::LESS),
+            separated_list1(tag_token_symbol(TokenType::GENERIC_SEP), identifier),
+            tag_token_symbol(TokenType::GREATER),
         )),
         |(lf, ids, ri)| {
             let range = lf.1.start.to(ri.1.end);
@@ -117,15 +117,15 @@ pub fn generic_type_def(input: Span) -> IResult<Span, Box<GenericDefNode>> {
 pub fn generic_param_def(input: Span) -> IResult<Span, Box<GenericParamNode>> {
     map_res(
         tuple((
-            tag_token(TokenType::LESS),
+            tag_token_symbol(TokenType::LESS),
             separated_list1(
-                tag_token(TokenType::GENERIC_SEP),
+                tag_token_symbol(TokenType::GENERIC_SEP),
                 alt((
                     map_res(type_name, |x| Ok::<_, Error>(Some(x))),
-                    map_res(tag_token(TokenType::INGNORE), |_| Ok::<_, Error>(None)),
+                    map_res(tag_token_word(TokenType::INGNORE), |_| Ok::<_, Error>(None)),
                 )),
             ),
-            tag_token(TokenType::GREATER),
+            tag_token_symbol(TokenType::GREATER),
         )),
         |(lf, ids, ri)| {
             let range = lf.1.start.to(ri.1.end);
@@ -148,12 +148,12 @@ pub fn generic_param_def(input: Span) -> IResult<Span, Box<GenericParamNode>> {
 pub fn trait_def(input: Span) -> IResult<Span, Box<TraitDefNode>> {
     map_res(
         tuple((
-            tag_token(TokenType::TRAIT),
+            tag_token_word(TokenType::TRAIT),
             identifier,
             opt(generic_type_def),
-            del_newline_or_space!(tag_token(TokenType::LBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::LBRACE)),
             many0(del_newline_or_space!(function_def)),
-            del_newline_or_space!(tag_token(TokenType::RBRACE)),
+            del_newline_or_space!(tag_token_symbol(TokenType::RBRACE)),
         )),
         |(_, id, generics, _, defs, (_, rr))| {
             let range = id.range().start.to(rr.end);


### PR DESCRIPTION
将 `token` 分为 `word` 和 `symbol`  
修复：
- [x] 捕获错误
- [ ] 错误容忍