### PR TITLE
feat: trait derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ use_statement = "use" identifier ("::" identifier)* ";" ;
 
 string_literal = "\"" [^"]* "\"" ;
 
-trait_def = "trait" identifier generic_type_def? "{" function_def* "}" ;
+trait_def = "trait" identifier generic_type_def? (":" type_add)? "{" function_def* "}" ;
+
+type_add = type_name ("+" type_name)* ;
 
 ```

--- a/src/ast/node/implement.rs
+++ b/src/ast/node/implement.rs
@@ -63,7 +63,8 @@ impl Node for ImplNode {
                             .add_label(t.range(), Some(("type {}".to_string(), vec![name])))
                             .add_to_ctx(ctx);
                     };
-                    sttp.impls.push(trait_tp);
+                    sttp.impls
+                        .insert(trait_tp.clone().borrow().get_full_elm_name(), trait_tp);
                 }
                 ctx.send_if_go_to_def(self.target.range(), sttp.range, sttp.path.clone());
             }

--- a/src/ast/node/mod.rs
+++ b/src/ast/node/mod.rs
@@ -243,6 +243,7 @@ impl<'a, 'ctx> Ctx<'a> {
         let expect = expect.unwrap();
         let range = node.range();
         let pri: Result<PrimaryNode, _> = (*node.clone()).try_into();
+        // basic type implicit cast
         if let Ok(pri) = pri {
             let num: Result<NumNode, _> = (*pri.value.clone()).try_into();
             if let Ok(numnode) = num {
@@ -333,16 +334,7 @@ impl<'a, 'ctx> Ctx<'a> {
                         // struct to trait
                         (PLType::TRAIT(t), PLType::STRUCT(st)) => {
                             let handle = builder.alloc("tmp_traitv", &expect.borrow(), self);
-                            if st
-                                .impls
-                                .iter()
-                                .find(|i| {
-                                    let ty1: &PLType = &i.borrow();
-                                    let ty2: &PLType = &expect.borrow();
-                                    ty1 == ty2
-                                })
-                                .is_none()
-                            {
+                            if !st.implements_trait(t) {
                                 return Err(mismatch_err!(
                                     self,
                                     range,

--- a/src/ast/node/types.rs
+++ b/src/ast/node/types.rs
@@ -408,7 +408,8 @@ impl StructDefNode {
             refs: Rc::new(RefCell::new(vec![])),
             doc: vec![],
             generic_map,
-            impls: vec![],
+            impls: FxHashMap::default(),
+            derives: vec![],
         })));
         builder.opaque_struct_type(&ctx.plmod.get_full_name(&self.id.name));
         _ = ctx.add_type(self.id.name.clone(), stu, self.id.range);

--- a/src/ast/pltype.rs
+++ b/src/ast/pltype.rs
@@ -632,10 +632,27 @@ pub struct STType {
     pub refs: Rc<RefCell<Vec<Location>>>,
     pub doc: Vec<Box<NodeEnum>>,
     pub generic_map: IndexMap<String, Rc<RefCell<PLType>>>,
-    pub impls: Vec<Rc<RefCell<PLType>>>,
+    pub impls: FxHashMap<String, Rc<RefCell<PLType>>>,
+    pub derives: Vec<Rc<RefCell<PLType>>>,
 }
 
 impl STType {
+    pub fn implements(&self, tp: &PLType) -> bool {
+        self.impls.get(&tp.get_full_elm_name()).is_some()
+    }
+    pub fn implements_trait(&self, tp: &STType) -> bool {
+        let re = self.impls.get(&tp.get_st_full_name()).is_some();
+        if !re {
+            return re;
+        }
+        for de in &tp.derives {
+            let re = self.implements(&de.borrow());
+            if !re {
+                return re;
+            }
+        }
+        true
+    }
     pub fn get_type_code(&self) -> u64 {
         let full_name = self.get_st_full_name();
         get_hash_code(full_name)

--- a/test/main.pi
+++ b/test/main.pi
@@ -153,6 +153,9 @@ impl TestTrait for mod1::Mod1 {
     }
 
 }
+impl TestTrait2 for mod1::Mod1 {
+
+}
 
 fn test_trait() void {
     let x = mod1::Mod1{
@@ -381,9 +384,13 @@ fn main() i64 {
     test_trait();
     return 0;
 }
-trait TestTrait {
+trait TestTrait:TestTrait2 {
     fn name() void;
     fn test_ret(i:i64) i64;
+}
+
+trait TestTrait2 {
+
 }
 
 fn test_many_params(a: i64, b: i64, c: i64, d: i64) void {


### PR DESCRIPTION
这个pr引入trait derive功能，即允许一个接口定义为多个接口的组合： 

```pl
trait A:B+C {

}
```
B+C就是新引入的功能。

## 注意点
A有fn a，B有fn b，那么一个结构体要实现 A，他要在impl A中实现函数a，并且在impl B中实现函数b才行，不能在impl A中实现函数b之类的。


## 存在问题
实际上上方写法，如果一个`struct` impl了A，但是没有impl B和C，那么严格来说他没有完全实现A，但是这个时候编译器不会报错。只有试图将该struct类型赋值给A类型的时候才会报错。不过我认为这种行为是可以被接受的
