### PR TITLE
fix: jit gc support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Debug
 Release
 kagari/test_dir
 planglib/thirdparty
+immix/llvm/cmake-build-debug/build.ninja

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "ctor",
  "fmt_macro",
  "llvm-sys",
+ "log",
  "node_macro",
  "range_macro",
  "test_parser_macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -62,42 +62,51 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -239,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
+checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -250,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
+checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -270,7 +279,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -308,6 +317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,21 +339,6 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "countme"
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -514,7 +514,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.11",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -602,13 +602,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -744,9 +744,9 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -887,25 +887,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -947,9 +947,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "link-cplusplus"
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lld_rs"
@@ -1213,7 +1213,7 @@ name = "pivot-lang"
 version = "0.1.0"
 dependencies = [
  "ariadne",
- "clap 4.2.0",
+ "clap 4.2.2",
  "colored",
  "crossbeam-channel",
  "derivative",
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1387,7 +1387,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1482,16 +1482,16 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.4"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1559,29 +1559,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1596,7 +1596,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1701,7 +1701,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1973,11 +1973,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1986,13 +1986,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2001,7 +2001,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2010,13 +2019,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2026,10 +2050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2038,10 +2074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2050,16 +2098,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ features = ["alloc"]
 
 
 [features]
-default = ["static"]
+default = ["static", "jit"]
 jit = ["vm"]
 static = ["immix/auto_gc"]
 

--- a/immix/build.rs
+++ b/immix/build.rs
@@ -8,6 +8,8 @@ fn main() {
         println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rerun-if-changed=llvm/plimmixprinter.cpp");
         println!("cargo:rerun-if-changed=llvm/plimmix.cpp");
+        println!("cargo:rerun-if-changed=llvm/memory_manager.cpp");
+        println!("cargo:rerun-if-changed=llvm/CMakeLists.txt");
         let dst = cmake::Config::new("llvm").static_crt(true).build();
         println!("cargo:rustc-link-search=native={}/build", dst.display());
         println!("cargo:rustc-link-lib=static=plimmix_plugin");

--- a/immix/llvm/CMakeLists.txt
+++ b/immix/llvm/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${LLVM_INCLUDE_DIRS})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 set(SOURCES
+        memory_manager.cpp
   plimmix.cpp
   plimmixprinter.cpp
 )

--- a/immix/llvm/memory_manager.cpp
+++ b/immix/llvm/memory_manager.cpp
@@ -1,0 +1,108 @@
+#include "llvm-c/ExecutionEngine.h"
+#include "llvm/ExecutionEngine/SectionMemoryManager.h"
+#include "llvm-c/Core.h"
+
+using namespace llvm;
+
+static bool didCallAllocateCodeSection;
+
+static SmallVector<uint8_t *, 10> stackMaps = {};
+typedef void (*stackmap_cb)(uint8_t *map);
+typedef int (*mainf)();
+static stackmap_cb finalize_cb = nullptr;
+
+static uint8_t *roundTripAllocateCodeSection(void *object, uintptr_t size,
+                                             unsigned alignment,
+                                             unsigned sectionID,
+                                             const char *sectionName)
+{
+
+  didCallAllocateCodeSection = true;
+  return static_cast<SectionMemoryManager *>(object)->allocateCodeSection(
+      size, alignment, sectionID, sectionName);
+}
+
+static uint8_t *roundTripAllocateDataSection(void *object, uintptr_t size,
+                                             unsigned alignment,
+                                             unsigned sectionID,
+                                             const char *sectionName,
+                                             LLVMBool isReadOnly)
+{
+  auto alloc_addr = static_cast<SectionMemoryManager *>(object)->allocateDataSection(
+      size, alignment, sectionID, sectionName, isReadOnly);
+  // printf("sec name: %s\n", sectionName);
+  auto mapName = "_GC_MAP_";
+  if (strncmp(sectionName, mapName, strlen(mapName)) == 0)
+  {
+    // printf("push back\n");
+    stackMaps.push_back(alloc_addr);
+  }
+  return alloc_addr;
+}
+
+static LLVMBool roundTripFinalizeMemory(void *object, char **errMsg)
+{
+  std::string errMsgString;
+  bool result =
+      static_cast<SectionMemoryManager *>(object)->finalizeMemory(&errMsgString);
+  if (result)
+  {
+    *errMsg = LLVMCreateMessage(errMsgString.c_str());
+    return 1;
+  }
+  else
+  {
+    // initialize the stack map
+    if (finalize_cb == nullptr)
+    {
+      *errMsg = LLVMCreateMessage(
+          "stack map initialize function is not registered. Please register on by RegisterStackMapLoadCallback");
+    }
+    else
+    {
+      for (int i = 0; i < stackMaps.size(); ++i)
+      {
+        // printf("finalize\n");
+        finalize_cb(stackMaps[i]);
+      }
+    }
+  }
+  return 0;
+}
+static void roundTripDestroy(void *object)
+{
+  delete static_cast<SectionMemoryManager *>(object);
+}
+extern "C"
+{
+  void CreatePLJITEngine(LLVMExecutionEngineRef *jit, LLVMModuleRef module, unsigned int opt, stackmap_cb cb)
+  {
+    finalize_cb = cb;
+    auto mem_manager = LLVMCreateSimpleMCJITMemoryManager(new SectionMemoryManager(),
+                                                          roundTripAllocateCodeSection,
+                                                          roundTripAllocateDataSection,
+                                                          roundTripFinalizeMemory,
+                                                          roundTripDestroy);
+    LLVMMCJITCompilerOptions Options;
+    LLVMInitializeMCJITCompilerOptions(&Options, sizeof(Options));
+    Options.MCJMM = mem_manager;
+    Options.OptLevel = opt;
+
+    char *Error;
+    //      LLVMExecutionEngineRef jit;
+
+    if (LLVMCreateMCJITCompilerForModule(jit, module, &Options,
+                                         sizeof(Options), &Error))
+    {
+      printf("fatal: create mcjit engine error!\n");
+      printf("%s\n", Error);
+      exit(1945);
+    }
+
+    //      LLVMRunStaticConstructors(jit);
+    //      auto f  = LLVMGetFunctionAddress(jit, "main");
+    //      auto m = (mainf)f;
+    //      auto ret = m();
+    //      printf("ret = %d \n", ret);
+  }
+}

--- a/immix/llvm/plimmix.cpp
+++ b/immix/llvm/plimmix.cpp
@@ -2,25 +2,92 @@
 
 // #include "llvm/CodeGen/GCStrategy.h"
 #include "llvm/IR/GCStrategy.h"
-#include "llvm/CodeGen/GCMetadata.h"
+#include "llvm/IR/BuiltinGCs.h"
 #include "llvm/Support/Compiler.h"
 #include "plimmixprinter.cpp"
 
 using namespace llvm;
 
-namespace {
-  class LLVM_LIBRARY_VISIBILITY PLImmixGC : public GCStrategy {
-  public:
-    PLImmixGC() {
-        UsesMetadata = true;
-        NeededSafePoints = true;
-    }
-  };
+namespace
+{
+    class LLVM_LIBRARY_VISIBILITY PLImmixGC : public GCStrategy
+    {
+    public:
+        PLImmixGC()
+        {
+            UsesMetadata = true;
+            NeededSafePoints = true;
+        }
+    };
 
-  GCRegistry::Add<PLImmixGC>
-  X("plimmix", "pivot-lang immix garbage collector.");
+    GCRegistry::Add<PLImmixGC>
+        X("plimmix", "pivot-lang immix garbage collector.");
 }
 
+extern "C" void LLVMLinkPLImmixGC()
+{
+    linkAllBuiltinGCs();
+}
 
-extern "C" void LLVMLinkPLImmixGC() {
+extern "C"
+{
+    /// The map for a single function's stack frame.  One of these is
+    ///        compiled as constant data into the executable for each function.
+    ///
+    /// Storage of metadata values is elided if the %metadata parameter to
+    /// @llvm.gcroot is null.
+    struct FrameMap
+    {
+        int32_t NumRoots;    //< Number of roots in stack frame.
+        int32_t NumMeta;     //< Number of metadata entries.  May be < NumRoots.
+        const void *Meta[0]; //< Metadata for each root.
+    };
+
+    /// A link in the dynamic shadow stack.  One of these is embedded in
+    ///        the stack frame of each function on the call stack.
+    struct StackEntry
+    {
+        StackEntry *Next;    //< Link to next stack entry (the caller's).
+        const FrameMap *Map; //< Pointer to constant FrameMap.
+        void *Roots[0];      //< Stack roots (in-place array).
+    };
+
+    /// The head of the singly-linked list of StackEntries.  Functions push
+    ///        and pop onto this in their prologue and epilogue.
+    ///
+    /// Since there is only a global list, this technique is not threadsafe.
+    thread_local StackEntry **llvm_gc_root_chain;
+
+    void SetShadowStackAddr(void *addr)
+    {
+        llvm_gc_root_chain = (StackEntry **)addr;
+    }
+
+    /// Calls Visitor(root, meta) for each GC root on the stack.
+    ///        root and meta are exactly the values passed to
+    ///        @llvm.gcroot.
+    ///
+    /// Visitor could be a function to recursively mark live objects.  Or it
+    /// might copy them to another heap or generation.
+    ///
+    /// @param Visitor A function to invoke for every GC root on the stack.
+    void visitGCRoots(void (*Visitor)(void **Root, const void *Meta))
+    {
+        for (StackEntry *R = *llvm_gc_root_chain; R; R = R->Next)
+        {
+            unsigned i = 0;
+
+            // For roots [0, NumMeta), the metadata pointer is in the FrameMap.
+            for (unsigned e = R->Map->NumMeta; i != e; ++i)
+            {
+                Visitor(&R->Roots[i], R->Map->Meta[i]);
+            }
+
+            // For roots [NumMeta, NumRoots), the metadata pointer is null.
+            for (unsigned e = R->Map->NumRoots; i != e; ++i)
+            {
+                Visitor(&R->Roots[i], NULL);
+            }
+        }
+    }
 }

--- a/immix/src/lib.rs
+++ b/immix/src/lib.rs
@@ -20,6 +20,7 @@ mod consts;
 mod llvm_stackmap;
 mod macros;
 mod mmap;
+mod shadow_stack;
 #[cfg(feature = "llvm_stackmap")]
 pub use llvm_stackmap::*;
 mod bigobj;
@@ -237,6 +238,8 @@ static GC_ID: AtomicUsize = AtomicUsize::new(0);
 
 static GC_STW_COUNT: AtomicUsize = AtomicUsize::new(0);
 
+pub(crate) static USE_SHADOW_STACK: AtomicBool = AtomicBool::new(false);
+
 pub static ENABLE_EVA: AtomicBool = AtomicBool::new(true);
 
 #[cfg(feature = "auto_gc")]
@@ -248,4 +251,13 @@ unsafe impl Sync for GAWrapper {}
 
 pub fn get_gc_stw_num() -> usize {
     GC_STW_COUNT.load(Ordering::SeqCst)
+}
+
+pub fn set_shadow_stack(b: bool) {
+    USE_SHADOW_STACK.store(b, Ordering::Relaxed);
+}
+
+#[cfg(feature = "llvm_gc_plugin")]
+pub unsafe fn set_shadow_stack_addr(addr: *mut u8) {
+    shadow_stack::SetShadowStackAddr(addr)
 }

--- a/immix/src/llvm_stackmap/mod.rs
+++ b/immix/src/llvm_stackmap/mod.rs
@@ -155,6 +155,12 @@ fn align_up_to(n: usize, align: usize) -> usize {
 #[cfg(feature = "llvm_gc_plugin")]
 extern "C" {
     fn LLVMLinkPLImmixGC();
+    pub fn CreatePLJITEngine(
+        engine: *mut u8,
+        module: *mut u8,
+        opt: u32,
+        cb: extern "C" fn(map: *mut u8),
+    );
 }
 
 /// Register the LLVM GC plugins.

--- a/immix/src/shadow_stack.rs
+++ b/immix/src/shadow_stack.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "llvm_gc_plugin")]
+pub type VisitF = extern "C" fn(root: *mut u8, obj_type: *mut u8);
+
+#[cfg(feature = "llvm_gc_plugin")]
+extern "C" {
+    pub fn visitGCRoots(visitor: VisitF);
+    pub fn SetShadowStackAddr(addr: *mut u8);
+}

--- a/internal_macro/Cargo.toml
+++ b/internal_macro/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 ctor = "0.1"
+log = "0.4"
+
 llvm-sys = { version = "140", optional = true }
 [dependencies.add_symbol_macro]
 path = "src/add_symbol_macro"

--- a/internal_macro/src/lib.rs
+++ b/internal_macro/src/lib.rs
@@ -18,6 +18,7 @@ pub unsafe fn add_symbol(name: &str, ptr: *const ()) {
     use llvm_sys::support;
     use std::os::raw::c_void;
     let name = std::ffi::CString::new(name).unwrap();
+    log::debug!("add symbol {} at {:p}", name.to_str().unwrap(), ptr);
     let addr = ptr as *mut c_void;
     support::LLVMAddSymbol(name.as_ptr(), addr)
 }

--- a/src/ast/compiler.rs
+++ b/src/ast/compiler.rs
@@ -96,6 +96,11 @@ lazy_static::lazy_static! {
 
 #[cfg(feature = "jit")]
 pub fn run(p: &Path, opt: OptimizationLevel) -> i64 {
+    // windows doesn't support jit with shadow stack yet
+    if cfg!(windows) {
+        eprintln!("jit is not yet supported on windows");
+        return 0;
+    }
     type MainFunc = unsafe extern "C" fn() -> i64;
     use std::ffi::CString;
 

--- a/src/ast/pass.rs
+++ b/src/ast/pass.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::{cell::RefCell, sync::atomic::AtomicBool};
 
 use immix::LLVM_GC_STRATEGY_NAME;
 use inkwell::{
@@ -17,9 +17,18 @@ pub struct GlobalMutWrapper<T> {
     pub inner: Mutex<RefCell<T>>,
 }
 
+pub static IS_JIT: AtomicBool = AtomicBool::new(false);
+
 pub fn run_immix_pass(module: &Module) {
     let ctx = module.get_context();
     let builder = ctx.create_builder();
+    if IS_JIT.load(std::sync::atomic::Ordering::Relaxed) {
+        // jit is using shadow stack, skip immix pass
+        module.get_functions().for_each(|f| {
+            f.set_gc("shadow-stack");
+        });
+        return;
+    }
     // add global _GC_MAP_
     let gcmap_name = "_GC_MAP_".to_string() + module.get_source_file_name().to_str().unwrap();
     let stack_map = module.add_global(ctx.i8_type(), Default::default(), &gcmap_name);

--- a/src/ast/pass.rs
+++ b/src/ast/pass.rs
@@ -20,8 +20,6 @@ pub struct GlobalMutWrapper<T> {
 pub static IS_JIT: AtomicBool = AtomicBool::new(false);
 
 pub fn run_immix_pass(module: &Module) {
-    let ctx = module.get_context();
-    let builder = ctx.create_builder();
     if IS_JIT.load(std::sync::atomic::Ordering::Relaxed) {
         // jit is using shadow stack, skip immix pass
         module.get_functions().for_each(|f| {
@@ -29,6 +27,8 @@ pub fn run_immix_pass(module: &Module) {
         });
         return;
     }
+    let ctx = module.get_context();
+    let builder = ctx.create_builder();
     // add global _GC_MAP_
     let gcmap_name = "_GC_MAP_".to_string() + module.get_source_file_name().to_str().unwrap();
     let stack_map = module.add_global(ctx.i8_type(), Default::default(), &gcmap_name);

--- a/src/ast/test.rs
+++ b/src/ast/test.rs
@@ -547,6 +547,7 @@ mod test {
                 printast: false,
                 flow: false,
                 fmt: false,
+                jit: true,
             },
         );
         // #[cfg(feature = "jit")]
@@ -577,6 +578,7 @@ mod test {
                 printast: true,
                 flow: false,
                 fmt: false,
+                jit: true,
             },
         );
         test_lsp::<Completions>(

--- a/src/ast/test.rs
+++ b/src/ast/test.rs
@@ -511,6 +511,48 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "jit")]
+    fn test_jit() {
+        use crate::ast::compiler::{compile, Options};
+        use std::path::PathBuf;
+        let _l = crate::utils::plc_new::tests::TEST_COMPILE_MUTEX
+            .lock()
+            .unwrap();
+        let out = "testjitout";
+        let docs = MemDocs::default();
+        let db = Database::default();
+        let input = MemDocsInput::new(
+            &db,
+            Arc::new(Mutex::new(RefCell::new(docs))),
+            "test/main.pi".to_string(),
+            Default::default(),
+            ActionType::Compile,
+            None,
+            None,
+        );
+        let outplb = "testjitout.bc";
+        compile(
+            &db,
+            input,
+            out.to_string(),
+            Options {
+                optimization: crate::ast::compiler::HashOptimizationLevel::None,
+                genir: true,
+                printast: false,
+                flow: false,
+                fmt: false,
+                jit: true,
+            },
+        );
+        assert!(
+            crate::ast::compiler::run(
+                &PathBuf::from(outplb).as_path(),
+                inkwell::OptimizationLevel::None,
+            ) == 0,
+            "jit compiled program exit with non-zero status"
+        );
+    }
+    #[test]
     fn test_compile() {
         let out = "testout";
         let exe = PathBuf::from(out);
@@ -535,8 +577,6 @@ mod test {
             None,
             None,
         );
-        // let outplb = "testout.bc";
-
         compile(
             &db,
             input,
@@ -547,14 +587,9 @@ mod test {
                 printast: false,
                 flow: false,
                 fmt: false,
-                jit: true,
+                jit: false,
             },
         );
-        // #[cfg(feature = "jit")]
-        // crate::ast::compiler::run(
-        //     &PathBuf::from(outplb).as_path(),
-        //     inkwell::OptimizationLevel::None,
-        // );
         let exe = dunce::canonicalize(&exe)
             .unwrap_or_else(|_| panic!("static compiled file not found {:?}", exe));
         let o = Command::new(exe.to_str().unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,10 @@ struct Cli {
     #[arg(long)]
     genir: bool,
 
+    /// jit compile
+    #[arg(long)]
+    jit: bool,
+
     /// optimization level, 0-3
     #[arg(short = 'O', value_parser, default_value = "0")]
     optimization: u64,
@@ -183,6 +187,7 @@ fn main() {
             flow: cli.flow,
             fmt,
             optimization: opt,
+            jit: cli.jit,
         };
         let action = if cli.flow {
             ActionType::Flow

--- a/src/utils/plc_new.rs
+++ b/src/utils/plc_new.rs
@@ -88,6 +88,7 @@ pub mod tests {
             flow: false,
             fmt: false,
             optimization: HashOptimizationLevel::Aggressive,
+            jit: false,
         };
 
         let input = MemDocsInput::new(

--- a/src/utils/plc_new.rs
+++ b/src/utils/plc_new.rs
@@ -109,7 +109,5 @@ pub mod tests {
 
         #[cfg(target_os = "windows")]
         assert!(fs::metadata("plc_new_testout.exe").is_ok());
-
-        assert!(fs::metadata("plc_new_testout.bc").is_ok());
     }
 }

--- a/test/test/string.pi
+++ b/test/test/string.pi
@@ -7,12 +7,12 @@ pub fn test_string() void {
     macros::test!(s);
     panic::assert(s.len == 13);
     panic::assert(s.byte_len == 13);
-    let ss = "你好啊！";
-    panic::assert(ss.len == 4);
-    panic::assert(ss.byte_len == 12);
+    let ss = "你好啊！\n";
+    panic::assert(ss.len == 5);
+    panic::assert(ss.byte_len == 13);
     s.append(ss);
-    panic::assert(s.len == 17);
-    panic::assert(s.byte_len == 25);
+    panic::assert(s.len == 18);
+    panic::assert(s.byte_len == 26);
     io::print_s(s);
     return;
 }


### PR DESCRIPTION
This pr adds supports for immix gc under jit mode, using llvm shadow stack api.

However, the implementation of llvm shadow stack is not thread safe, and may never be. In immix gc's perspective, simply make shadow stack thread-local may solve the issue, but any access to thread-local globals results in segment fault on mac silicon device. This might be fixed in the newer version of llvm.

I also added a custom memory manager for `MCJIT`, which has ability to read stackmap section while running the code just in time. Meanwhile the code doesn't really work, as the llvm-14's `statepoint` api seems buggy and refused to cooperate. You may find some efforts to add support for `statepoint` api in branch `feat/statepoint`.

This pr doesn't change any documentation, I may repair them altogether later.

Seems llvm shadow stack api doen't work find for windows, skip it for now.
