### PR TITLE
feature: support plc build command and do small refactor

### DIFF
--- a/src/ast/compiler/options.rs
+++ b/src/ast/compiler/options.rs
@@ -23,6 +23,16 @@ pub enum HashOptimizationLevel {
     Aggressive = 3,
 }
 
+pub fn convert(optimization: u64) -> HashOptimizationLevel {
+    match optimization {
+        0 => HashOptimizationLevel::None,
+        1 => HashOptimizationLevel::Less,
+        2 => HashOptimizationLevel::Default,
+        3 => HashOptimizationLevel::Aggressive,
+        _ => panic!("optimization level must be 0-3"),
+    }
+}
+
 impl Default for HashOptimizationLevel {
     /// Returns the default value for `OptimizationLevel`, namely `OptimizationLevel::Default`.
     fn default() -> Self {

--- a/src/lsp/mem_docs.rs
+++ b/src/lsp/mem_docs.rs
@@ -14,7 +14,7 @@ use crate::{
         range::Pos,
     },
     nomparser::SourceProgram,
-    utils::read_config::{get_config, get_config_path, Config},
+    utils::read_config::{get_config, search_config_file, Config},
     Db,
 };
 
@@ -146,7 +146,7 @@ impl MemDocsInput {
             return None;
         }
         let mut file = f.unwrap().to_string_lossy().to_string();
-        let path = get_config_path(file.clone());
+        let path = search_config_file(file.clone());
         if path.is_err() {
             log::debug!("lsp error: {}", path.err().unwrap());
             return None;


### PR DESCRIPTION
# Changes

- add command `plc build`, the behavior of `plc build main.pi` is as same as `plc main.pi`
- support `plc fmt main.pi`, previously we can do it only by `plc main.pi fmt`.
- split the command logic into different functions
- add some todo for the future

