### PR TITLE
feat: extend inference logic to support more complex cases

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,6 @@
             "request": "attach",
             "name": "debug lsp",
             "program": "plc",
-            "preLaunchTask": "install debug plc"
         },
         {
             "type": "pivot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ name = "plc"
 path = "src/main.rs"
 
 [lib]
-name = "plc"
+name = "plclib"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 

--- a/planglib/std/buf.pi
+++ b/planglib/std/buf.pi
@@ -59,7 +59,7 @@ impl Buffer {
         }
         // otherwise, copy the data out of the buffer
 
-        let dst_arr = [u8*len as i64;];
+        let dst_arr:[u8] = [u8*len as i64;];
         arr_copy(self.data, dst_arr, len as i64);
         // return the data
         return dst_arr;

--- a/src/ast/builder/llvmbuilder.rs
+++ b/src/ast/builder/llvmbuilder.rs
@@ -3060,6 +3060,9 @@ impl<'a, 'ctx> IRBuilder<'a, 'ctx> for LLVMBuilder<'a, 'ctx> {
     /// 闭包函数相比原函数多出一个参数（第一个），用于存放闭包的环境。在函数为纯函数的情况，
     /// 该值不会被使用，因此可以直接传入null。
     fn get_closure_trampoline(&self, f: ValueHandle) -> ValueHandle {
+        if !self.get_llvm_value(f).unwrap().is_function_value() {
+            return f;
+        }
         let ori_f = self.get_llvm_value(f).unwrap().into_function_value();
         let name = ori_f.get_name();
         let trampoline_name = format!("{}__trampoline", name.to_str().unwrap());

--- a/src/ast/builder/llvmbuilder.rs
+++ b/src/ast/builder/llvmbuilder.rs
@@ -2828,11 +2828,15 @@ impl<'a, 'ctx> IRBuilder<'a, 'ctx> for LLVMBuilder<'a, 'ctx> {
         let ftp = self.mark_fn_tp(ptrtp);
         let name = v.get_full_name() + "_visitorf@";
 
+        let linkage = if v.is_tuple {
+            Linkage::Internal
+        } else {
+            Linkage::LinkOnceAny
+        };
+
         let f = match self.module.get_function(&name) {
             Some(f) => f,
-            None => self
-                .module
-                .add_function(&name, ftp, Some(Linkage::LinkOnceAny)),
+            None => self.module.add_function(&name, ftp, Some(linkage)),
         };
         self.used.borrow_mut().push(f);
 

--- a/src/ast/builder/llvmbuilder.rs
+++ b/src/ast/builder/llvmbuilder.rs
@@ -996,7 +996,6 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
             ctx.run_in_type_mod(fnvalue, |ctx, fnvalue| {
                 let mut param_types = vec![];
                 for param_pltype in fnvalue.fntype.param_pltypes.iter() {
-                    // eprintln!("param_pltype: {:?}", param_pltype);
                     param_types.push(
                         self.get_basic_type_op(
                             &param_pltype
@@ -1021,10 +1020,9 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
                         !fnvalue.is_declare && fnvalue.name != "main",
                     )
                     .fn_type(&param_types, false);
-                Ok(fn_type)
+                fn_type
             })
         })
-        .unwrap()
     }
 
     fn get_closure_fn_type(&self, closure: &ClosureType, ctx: &mut Ctx<'a>) -> FunctionType<'ctx> {

--- a/src/ast/builder/llvmbuilder.rs
+++ b/src/ast/builder/llvmbuilder.rs
@@ -899,6 +899,7 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
             | PLType::Void
             | PLType::Generic(_)
             | PLType::PlaceHolder(_)
+            | PLType::PartialInfered(_)
             | PLType::Unknown => (),
         }
         let i = self
@@ -1121,6 +1122,7 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
                 Some(self.context.struct_type(&fields, false).into())
             }
             PLType::Unknown => None,
+            PLType::PartialInfered(_) => None,
         }
     }
     /// # get_ret_type
@@ -1544,6 +1546,7 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
             }
             PLType::Closure(_) => self.get_ditype(&PLType::Primitive(PriType::I64), ctx),
             PLType::Unknown => None, // TODO
+            PLType::PartialInfered(_) => None,
         }
     }
 
@@ -2909,6 +2912,7 @@ impl<'a, 'ctx> IRBuilder<'a, 'ctx> for LLVMBuilder<'a, 'ctx> {
                 | PLType::Void
                 | PLType::Generic(_)
                 | PLType::PlaceHolder(_)
+                | PLType::PartialInfered(_)
                 | PLType::Unknown => (),
             }
             // 其他为原子类型，跳过

--- a/src/ast/builder/llvmbuilder.rs
+++ b/src/ast/builder/llvmbuilder.rs
@@ -576,6 +576,9 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
         (casted_result.into_pointer_value(), llvmtp)
     }
 
+    /// # get_sp
+    ///
+    /// get the stack pointer, return as i64
     fn get_sp(&self) -> inkwell::values::IntValue<'ctx> {
         let fp_asm_ftp = self
             .i8ptr()
@@ -861,7 +864,7 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
             | PLType::Void
             | PLType::Generic(_)
             | PLType::PlaceHolder(_)
-            | PLType::PartialInfered(_)
+            | PLType::PartialInferred(_)
             | PLType::Unknown => (),
         }
         let i = self
@@ -1084,7 +1087,7 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
                 Some(self.context.struct_type(&fields, false).into())
             }
             PLType::Unknown => None,
-            PLType::PartialInfered(_) => None,
+            PLType::PartialInferred(_) => None,
         }
     }
     /// # get_ret_type
@@ -1508,7 +1511,7 @@ impl<'a, 'ctx> LLVMBuilder<'a, 'ctx> {
             }
             PLType::Closure(_) => self.get_ditype(&PLType::Primitive(PriType::I64), ctx),
             PLType::Unknown => None, // TODO
-            PLType::PartialInfered(_) => None,
+            PLType::PartialInferred(_) => None,
         }
     }
 
@@ -2774,6 +2777,7 @@ impl<'a, 'ctx> IRBuilder<'a, 'ctx> for LLVMBuilder<'a, 'ctx> {
         let name = v.get_full_name() + "_visitorf@";
 
         let linkage = if v.is_tuple {
+            // tuple will not be used outside of the current module
             Linkage::Internal
         } else {
             Linkage::LinkOnceAny
@@ -2856,7 +2860,7 @@ impl<'a, 'ctx> IRBuilder<'a, 'ctx> for LLVMBuilder<'a, 'ctx> {
                 | PLType::Void
                 | PLType::Generic(_)
                 | PLType::PlaceHolder(_)
-                | PLType::PartialInfered(_)
+                | PLType::PartialInferred(_)
                 | PLType::Unknown => (),
             }
             // 其他为原子类型，跳过
@@ -3005,6 +3009,7 @@ impl<'a, 'ctx> IRBuilder<'a, 'ctx> for LLVMBuilder<'a, 'ctx> {
     /// 该值不会被使用，因此可以直接传入null。
     fn get_closure_trampoline(&self, f: ValueHandle) -> ValueHandle {
         if !self.get_llvm_value(f).unwrap().is_function_value() {
+            // already a closure
             return f;
         }
         let ori_f = self.get_llvm_value(f).unwrap().into_function_value();

--- a/src/ast/ctx.rs
+++ b/src/ast/ctx.rs
@@ -915,7 +915,7 @@ impl<'a, 'ctx> Ctx<'a> {
         u: &TP,
         mut f: F,
     ) -> R {
-        if u.get_path() != self.plmod.path {
+        if u.get_path() != self.plmod.path && !u.get_path().is_empty() {
             let ori_mod = unsafe { &*self.origin_mod as &Mod };
             let m = if u.get_path() == ori_mod.path {
                 ori_mod.clone()

--- a/src/ast/ctx.rs
+++ b/src/ast/ctx.rs
@@ -1095,6 +1095,11 @@ impl<'a, 'ctx> Ctx<'a> {
     }
 }
 
+/// # real_tp
+///
+/// PartialInferred is just a wrapper for real type
+///
+/// This function will unwrap it recursively
 fn real_tp(pltype: Arc<RefCell<PLType>>) -> Arc<RefCell<PLType>> {
     match &*pltype.clone().borrow() {
         PLType::PartialInferred(p) => real_tp(p.clone()),

--- a/src/ast/ctx.rs
+++ b/src/ast/ctx.rs
@@ -657,7 +657,8 @@ impl<'a, 'ctx> Ctx<'a> {
         if self.table.contains_key(&name) {
             return Err(self.add_diag(range.new_err(ErrorCode::REDECLARATION)));
         }
-        self.add_symbol_without_check(name, pv, pltype, range, is_glob, is_extern)
+
+        self.add_symbol_without_check(name, pv, real_tp(pltype), range, is_glob, is_extern)
     }
     pub fn add_symbol_without_check(
         &mut self,
@@ -1091,6 +1092,13 @@ impl<'a, 'ctx> Ctx<'a> {
         } else if let Some(father) = &self.father {
             father.try_set_closure_alloca_bb(bb);
         }
+    }
+}
+
+fn real_tp(pltype: Arc<RefCell<PLType>>) -> Arc<RefCell<PLType>> {
+    match &*pltype.clone().borrow() {
+        PLType::PartialInfered(p) => real_tp(p.clone()),
+        _ => pltype,
     }
 }
 

--- a/src/ast/ctx.rs
+++ b/src/ast/ctx.rs
@@ -896,11 +896,12 @@ impl<'a, 'ctx> Ctx<'a> {
         self.plmod = plmod;
         m
     }
-    pub fn protect_generic_context<'b, T, F: FnMut(&mut Ctx<'a>) -> Result<T, PLDiag>>(
+
+    pub fn protect_generic_context<'b, T, F: FnMut(&mut Ctx<'a>) -> T>(
         &mut self,
         generic_map: &IndexMap<String, Arc<RefCell<PLType>>>,
         mut f: F,
-    ) -> Result<T, PLDiag> {
+    ) -> T {
         let mp = self.generic_types.clone();
         for (name, pltype) in generic_map.iter() {
             self.add_generic_type(name.clone(), pltype.clone());

--- a/src/ast/ctx.rs
+++ b/src/ast/ctx.rs
@@ -843,7 +843,7 @@ impl<'a, 'ctx> Ctx<'a> {
                 if self.get_file() != fnvalue.get_path() {
                     return;
                 }
-                if !fnvalue.fntype.method && !fnvalue.in_trait {
+                if !fnvalue.fntype.st_method && !fnvalue.in_trait {
                     self.plmod
                         .doc_symbols
                         .borrow_mut()

--- a/src/ast/ctx.rs
+++ b/src/ast/ctx.rs
@@ -1097,7 +1097,7 @@ impl<'a, 'ctx> Ctx<'a> {
 
 fn real_tp(pltype: Arc<RefCell<PLType>>) -> Arc<RefCell<PLType>> {
     match &*pltype.clone().borrow() {
-        PLType::PartialInfered(p) => real_tp(p.clone()),
+        PLType::PartialInferred(p) => real_tp(p.clone()),
         _ => pltype,
     }
 }

--- a/src/ast/ctx/generic.rs
+++ b/src/ast/ctx/generic.rs
@@ -123,7 +123,6 @@ impl<'a> Ctx<'a> {
                         .iter()
                         .any(|lt| !self.eq(lt.clone(), r.clone()).eq)
                     {
-                        // eprintln!("lt:{:?},r:{:?}", l, r);
                         return EqRes {
                             eq: false,
                             need_up_cast: false,

--- a/src/ast/ctx/generic.rs
+++ b/src/ast/ctx/generic.rs
@@ -123,6 +123,7 @@ impl<'a> Ctx<'a> {
                         .iter()
                         .any(|lt| !self.eq(lt.clone(), r.clone()).eq)
                     {
+                        // eprintln!("lt:{:?},r:{:?}", l, r);
                         return EqRes {
                             eq: false,
                             need_up_cast: false,

--- a/src/ast/diag.rs
+++ b/src/ast/diag.rs
@@ -19,7 +19,7 @@ macro_rules! define_diag {
         ),*
     ) => {
         paste::paste! {
-            #[derive(Debug, PartialEq, Clone, Copy, Eq, Hash, Default)]
+            #[derive(Debug, PartialEq, Clone, Copy, Eq, Hash, Default, PartialOrd, Ord)]
             #[allow(non_camel_case_types, dead_code)]
             #[allow(clippy::upper_case_acronyms)]
             pub enum [<$level:camel Code>] {
@@ -178,7 +178,7 @@ define_diag! {
     UNUSED_FUNCTION = "unused function",
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DiagCode {
     Err(ErrorCode),
     Warn(WarnCode),
@@ -210,13 +210,13 @@ use super::{
 };
 
 #[range]
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PLLabel {
     file: String,
     txt: Option<(String, Vec<String>)>,
 }
 #[range]
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PLDiagRaw {
     code: DiagCode,
     help: Option<String>,
@@ -225,7 +225,7 @@ pub struct PLDiagRaw {
 }
 /// # PLDiag
 /// Diagnostic for pivot-lang
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PLDiag {
     pub raw: Box<PLDiagRaw>,
 }

--- a/src/ast/diag.rs
+++ b/src/ast/diag.rs
@@ -78,6 +78,7 @@ define_diag!(
     INVALID_STRUCT_DEF = "invalid struct definition",
     UNDEFINED_TYPE = "undefined type",
     UNKNOWN_TYPE = "unknown type",
+    TYPE_CANNOT_BE_FULLY_INFERRED = "type cannot be fully inferred",
     RETURN_VALUE_IN_VOID_FUNCTION = "return value in void function",
     RETURN_TYPE_MISMATCH = "return type mismatch",
     NO_RETURN_VALUE_IN_NON_VOID_FUNCTION = "non void function must have a return value",

--- a/src/ast/diag.rs
+++ b/src/ast/diag.rs
@@ -166,6 +166,7 @@ define_diag!(
     THE_TARGET_TRAIT_CANNOT_BE_INSTANTIATED = "the target trait type cannot be instantiated",
     MACRO_EXPAND_DEPTH_TOO_DEEP = "macro expand depth too deep",
     GLOBAL_MUST_BE_POINTER = "global must be pointer type",
+    ILLEGAL_GENERIC_PARAM = "illegal generic parameter",
 );
 
 define_diag! {

--- a/src/ast/expects/test_diag.pi.expect
+++ b/src/ast/expects/test_diag.pi.expect
@@ -88,23 +88,48 @@
     PLDiag {
         raw: PLDiagRaw {
             code: Err(
-                TYPE_MISMATCH,
+                ILLEGAL_GENERIC_PARAM,
             ),
             help: Some(
                 "missing impl for trait(s): `TestTrait`",
             ),
-            labels: [],
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "parameter `{}` defined in `{}`",
+                            [
+                                "T",
+                                "BInner",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 16,
+                            column: 15,
+                            offset: 125,
+                        },
+                        end: Pos {
+                            line: 16,
+                            column: 16,
+                            offset: 126,
+                        },
+                    },
+                },
+            ],
             source: None,
             range: Range {
                 start: Pos {
                     line: 13,
-                    column: 15,
-                    offset: 104,
+                    column: 8,
+                    offset: 97,
                 },
                 end: Pos {
                     line: 13,
-                    column: 16,
-                    offset: 105,
+                    column: 14,
+                    offset: 103,
                 },
             },
         },

--- a/src/ast/expects/test_diag.pi.expect
+++ b/src/ast/expects/test_diag.pi.expect
@@ -2,6 +2,578 @@
     PLDiag {
         raw: PLDiagRaw {
             code: Err(
+                TYPE_CANNOT_BE_FULLY_INFERRED,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 26,
+                    column: 9,
+                    offset: 303,
+                },
+                end: Pos {
+                    line: 26,
+                    column: 10,
+                    offset: 304,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                TYPE_CANNOT_BE_FULLY_INFERRED,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 27,
+                    column: 9,
+                    offset: 326,
+                },
+                end: Pos {
+                    line: 27,
+                    column: 11,
+                    offset: 328,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                RETURN_TYPE_MISMATCH,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 78,
+                    column: 5,
+                    offset: 826,
+                },
+                end: Pos {
+                    line: 78,
+                    column: 22,
+                    offset: 843,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                FUNCTION_MUST_HAVE_RETURN,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 68,
+                    column: 2,
+                    offset: 723,
+                },
+                end: Pos {
+                    line: 68,
+                    column: 2,
+                    offset: 723,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                MISSING_SEMI,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 31,
+                    column: 12,
+                    offset: 367,
+                },
+                end: Pos {
+                    line: 31,
+                    column: 12,
+                    offset: 367,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                MISSING_SEMI,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 33,
+                    column: 14,
+                    offset: 403,
+                },
+                end: Pos {
+                    line: 33,
+                    column: 14,
+                    offset: 403,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                MISSING_SEMI,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 34,
+                    column: 16,
+                    offset: 419,
+                },
+                end: Pos {
+                    line: 34,
+                    column: 16,
+                    offset: 419,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                UNRESOLVED_MODULE,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 89,
+                    column: 13,
+                    offset: 985,
+                },
+                end: Pos {
+                    line: 89,
+                    column: 15,
+                    offset: 987,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                TYPE_MISMATCH,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type `{}`",
+                            [
+                                "AA",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 22,
+                            column: 9,
+                            offset: 207,
+                        },
+                        end: Pos {
+                            line: 22,
+                            column: 10,
+                            offset: 208,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type `{}`",
+                            [
+                                "f64",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 22,
+                            column: 17,
+                            offset: 215,
+                        },
+                        end: Pos {
+                            line: 22,
+                            column: 20,
+                            offset: 218,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 22,
+                    column: 17,
+                    offset: 215,
+                },
+                end: Pos {
+                    line: 22,
+                    column: 20,
+                    offset: 218,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                ILLEGAL_SELF_RECURSION,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "in type {}",
+                            [
+                                "selfref",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 51,
+                            column: 8,
+                            offset: 529,
+                        },
+                        end: Pos {
+                            line: 51,
+                            column: 16,
+                            offset: 537,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "in type {}",
+                            [
+                                "selfref2",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 47,
+                            column: 8,
+                            offset: 493,
+                        },
+                        end: Pos {
+                            line: 47,
+                            column: 15,
+                            offset: 500,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 52,
+                    column: 7,
+                    offset: 546,
+                },
+                end: Pos {
+                    line: 52,
+                    column: 14,
+                    offset: 553,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                INVALID_UNION_CAST,
+            ),
+            help: Some(
+                "either add a new member to the union type or cast to a member of the union type",
+            ),
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "target type is `{}`",
+                            [
+                                "f32",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 25,
+                            column: 20,
+                            offset: 289,
+                        },
+                        end: Pos {
+                            line: 25,
+                            column: 23,
+                            offset: 292,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type of the expression is `{}`",
+                            [
+                                "AA",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 25,
+                            column: 14,
+                            offset: 283,
+                        },
+                        end: Pos {
+                            line: 25,
+                            column: 16,
+                            offset: 285,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 25,
+                    column: 14,
+                    offset: 283,
+                },
+                end: Pos {
+                    line: 25,
+                    column: 23,
+                    offset: 292,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                INVALID_DIRECT_UNION_CAST,
+            ),
+            help: Some(
+                "cast a union to its member type directly is not allowed, use `?` or `!` after the cast expression",
+            ),
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "add `{}` or `{}` to make it legal",
+                            [
+                                "?",
+                                "!",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 24,
+                            column: 22,
+                            offset: 268,
+                        },
+                        end: Pos {
+                            line: 24,
+                            column: 22,
+                            offset: 268,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "target type is `{}`",
+                            [
+                                "f32",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 24,
+                            column: 19,
+                            offset: 265,
+                        },
+                        end: Pos {
+                            line: 24,
+                            column: 22,
+                            offset: 268,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type of the expression is `{}`",
+                            [
+                                "AA",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 24,
+                            column: 13,
+                            offset: 259,
+                        },
+                        end: Pos {
+                            line: 24,
+                            column: 15,
+                            offset: 261,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 24,
+                    column: 13,
+                    offset: 259,
+                },
+                end: Pos {
+                    line: 24,
+                    column: 22,
+                    offset: 268,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                UNION_DOES_NOT_CONTAIN_TYPE,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 26,
+                    column: 19,
+                    offset: 313,
+                },
+                end: Pos {
+                    line: 26,
+                    column: 22,
+                    offset: 316,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                INVALID_IS_EXPR,
+            ),
+            help: Some(
+                "`is` can only be used on union or trait types",
+            ),
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 27,
+                    column: 14,
+                    offset: 331,
+                },
+                end: Pos {
+                    line: 27,
+                    column: 22,
+                    offset: 339,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                DERIVE_TRAIT_NOT_IMPL,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "the derive trait {} not impl",
+                            [
+                                "TA",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 38,
+                            column: 7,
+                            offset: 441,
+                        },
+                        end: Pos {
+                            line: 38,
+                            column: 9,
+                            offset: 443,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 44,
+                    column: 6,
+                    offset: 472,
+                },
+                end: Pos {
+                    line: 44,
+                    column: 8,
+                    offset: 474,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
                 CYCLE_DEPENDENCY,
             ),
             help: None,
@@ -88,117 +660,21 @@
     PLDiag {
         raw: PLDiagRaw {
             code: Err(
-                ILLEGAL_GENERIC_PARAM,
-            ),
-            help: Some(
-                "missing impl for trait(s): `TestTrait`",
-            ),
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "parameter `{}` defined in `{}`",
-                            [
-                                "T",
-                                "BInner",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 16,
-                            column: 15,
-                            offset: 125,
-                        },
-                        end: Pos {
-                            line: 16,
-                            column: 16,
-                            offset: 126,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 13,
-                    column: 8,
-                    offset: 97,
-                },
-                end: Pos {
-                    line: 13,
-                    column: 14,
-                    offset: 103,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                TYPE_MISMATCH,
+                YIELD_RETURN_MUST_BE_IN_GENERATOR,
             ),
             help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type `{}`",
-                            [
-                                "AA",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 22,
-                            column: 9,
-                            offset: 207,
-                        },
-                        end: Pos {
-                            line: 22,
-                            column: 10,
-                            offset: 208,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type `{}`",
-                            [
-                                "f64",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 22,
-                            column: 17,
-                            offset: 215,
-                        },
-                        end: Pos {
-                            line: 22,
-                            column: 20,
-                            offset: 218,
-                        },
-                    },
-                },
-            ],
+            labels: [],
             source: None,
             range: Range {
                 start: Pos {
-                    line: 22,
-                    column: 17,
-                    offset: 215,
+                    line: 67,
+                    column: 5,
+                    offset: 706,
                 },
                 end: Pos {
-                    line: 22,
+                    line: 67,
                     column: 20,
-                    offset: 218,
+                    offset: 721,
                 },
             },
         },
@@ -206,438 +682,21 @@
     PLDiag {
         raw: PLDiagRaw {
             code: Err(
-                INVALID_DIRECT_UNION_CAST,
-            ),
-            help: Some(
-                "cast a union to its member type directly is not allowed, use `?` or `!` after the cast expression",
-            ),
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type of the expression is `{}`",
-                            [
-                                "AA",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 24,
-                            column: 13,
-                            offset: 259,
-                        },
-                        end: Pos {
-                            line: 24,
-                            column: 15,
-                            offset: 261,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "target type is `{}`",
-                            [
-                                "f32",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 24,
-                            column: 19,
-                            offset: 265,
-                        },
-                        end: Pos {
-                            line: 24,
-                            column: 22,
-                            offset: 268,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "add `{}` or `{}` to make it legal",
-                            [
-                                "?",
-                                "!",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 24,
-                            column: 22,
-                            offset: 268,
-                        },
-                        end: Pos {
-                            line: 24,
-                            column: 22,
-                            offset: 268,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 24,
-                    column: 13,
-                    offset: 259,
-                },
-                end: Pos {
-                    line: 24,
-                    column: 22,
-                    offset: 268,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                INVALID_UNION_CAST,
-            ),
-            help: Some(
-                "either add a new member to the union type or cast to a member of the union type",
-            ),
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type of the expression is `{}`",
-                            [
-                                "AA",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 25,
-                            column: 14,
-                            offset: 283,
-                        },
-                        end: Pos {
-                            line: 25,
-                            column: 16,
-                            offset: 285,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "target type is `{}`",
-                            [
-                                "f32",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 25,
-                            column: 20,
-                            offset: 289,
-                        },
-                        end: Pos {
-                            line: 25,
-                            column: 23,
-                            offset: 292,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 25,
-                    column: 14,
-                    offset: 283,
-                },
-                end: Pos {
-                    line: 25,
-                    column: 23,
-                    offset: 292,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                UNION_DOES_NOT_CONTAIN_TYPE,
+                GENERATOR_FN_MUST_RET_ITER,
             ),
             help: None,
             labels: [],
             source: None,
             range: Range {
                 start: Pos {
-                    line: 26,
-                    column: 19,
-                    offset: 313,
+                    line: 71,
+                    column: 21,
+                    offset: 746,
                 },
                 end: Pos {
-                    line: 26,
-                    column: 22,
-                    offset: 316,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                INVALID_IS_EXPR,
-            ),
-            help: Some(
-                "`is` can only be used on union or trait types",
-            ),
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 27,
-                    column: 14,
-                    offset: 331,
-                },
-                end: Pos {
-                    line: 27,
-                    column: 22,
-                    offset: 339,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                MISSING_SEMI,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 31,
-                    column: 12,
-                    offset: 367,
-                },
-                end: Pos {
-                    line: 31,
-                    column: 12,
-                    offset: 367,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Warn(
-                UNUSED_VARIABLE,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "Unused variable `{}`",
-                            [
-                                "a",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 33,
-                            column: 9,
-                            offset: 398,
-                        },
-                        end: Pos {
-                            line: 33,
-                            column: 10,
-                            offset: 399,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 33,
-                    column: 9,
-                    offset: 398,
-                },
-                end: Pos {
-                    line: 33,
-                    column: 10,
-                    offset: 399,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                MISSING_SEMI,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 33,
-                    column: 14,
-                    offset: 403,
-                },
-                end: Pos {
-                    line: 33,
-                    column: 14,
-                    offset: 403,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                MISSING_SEMI,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 34,
-                    column: 16,
-                    offset: 419,
-                },
-                end: Pos {
-                    line: 34,
-                    column: 16,
-                    offset: 419,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                DERIVE_TRAIT_NOT_IMPL,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "the derive trait {} not impl",
-                            [
-                                "TA",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 38,
-                            column: 7,
-                            offset: 441,
-                        },
-                        end: Pos {
-                            line: 38,
-                            column: 9,
-                            offset: 443,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 44,
-                    column: 6,
-                    offset: 472,
-                },
-                end: Pos {
-                    line: 44,
-                    column: 8,
-                    offset: 474,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                ILLEGAL_SELF_RECURSION,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "in type {}",
-                            [
-                                "selfref2",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 47,
-                            column: 8,
-                            offset: 493,
-                        },
-                        end: Pos {
-                            line: 47,
-                            column: 15,
-                            offset: 500,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "in type {}",
-                            [
-                                "selfref",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 51,
-                            column: 8,
-                            offset: 529,
-                        },
-                        end: Pos {
-                            line: 51,
-                            column: 16,
-                            offset: 537,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 52,
-                    column: 7,
-                    offset: 546,
-                },
-                end: Pos {
-                    line: 52,
-                    column: 14,
-                    offset: 553,
+                    line: 71,
+                    column: 24,
+                    offset: 749,
                 },
             },
         },
@@ -691,94 +750,6 @@
     PLDiag {
         raw: PLDiagRaw {
             code: Err(
-                YIELD_RETURN_MUST_BE_IN_GENERATOR,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 67,
-                    column: 5,
-                    offset: 706,
-                },
-                end: Pos {
-                    line: 67,
-                    column: 20,
-                    offset: 721,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                FUNCTION_MUST_HAVE_RETURN,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 68,
-                    column: 2,
-                    offset: 723,
-                },
-                end: Pos {
-                    line: 68,
-                    column: 2,
-                    offset: 723,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                GENERATOR_FN_MUST_RET_ITER,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 71,
-                    column: 21,
-                    offset: 746,
-                },
-                end: Pos {
-                    line: 71,
-                    column: 24,
-                    offset: 749,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                RETURN_TYPE_MISMATCH,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 78,
-                    column: 5,
-                    offset: 826,
-                },
-                end: Pos {
-                    line: 78,
-                    column: 22,
-                    offset: 843,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
                 MACRO_EXPAND_DEPTH_TOO_DEEP,
             ),
             help: None,
@@ -801,21 +772,324 @@
     PLDiag {
         raw: PLDiagRaw {
             code: Err(
-                UNRESOLVED_MODULE,
+                ILLEGAL_GENERIC_PARAM,
             ),
-            help: None,
-            labels: [],
+            help: Some(
+                "missing impl for trait(s): `TestTrait`",
+            ),
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "parameter `{}` defined in `{}`",
+                            [
+                                "T",
+                                "BInner",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 16,
+                            column: 15,
+                            offset: 125,
+                        },
+                        end: Pos {
+                            line: 16,
+                            column: 16,
+                            offset: 126,
+                        },
+                    },
+                },
+            ],
             source: None,
             range: Range {
                 start: Pos {
-                    line: 89,
-                    column: 13,
-                    offset: 985,
+                    line: 13,
+                    column: 8,
+                    offset: 97,
                 },
                 end: Pos {
-                    line: 89,
-                    column: 15,
-                    offset: 987,
+                    line: 13,
+                    column: 14,
+                    offset: 103,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "a",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 22,
+                            column: 9,
+                            offset: 207,
+                        },
+                        end: Pos {
+                            line: 22,
+                            column: 10,
+                            offset: 208,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 22,
+                    column: 9,
+                    offset: 207,
+                },
+                end: Pos {
+                    line: 22,
+                    column: 10,
+                    offset: 208,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "a",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 33,
+                            column: 9,
+                            offset: 398,
+                        },
+                        end: Pos {
+                            line: 33,
+                            column: 10,
+                            offset: 399,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 33,
+                    column: 9,
+                    offset: 398,
+                },
+                end: Pos {
+                    line: 33,
+                    column: 10,
+                    offset: 399,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "b",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 24,
+                            column: 9,
+                            offset: 255,
+                        },
+                        end: Pos {
+                            line: 24,
+                            column: 10,
+                            offset: 256,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 24,
+                    column: 9,
+                    offset: 255,
+                },
+                end: Pos {
+                    line: 24,
+                    column: 10,
+                    offset: 256,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "bb",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 25,
+                            column: 9,
+                            offset: 278,
+                        },
+                        end: Pos {
+                            line: 25,
+                            column: 11,
+                            offset: 280,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 25,
+                    column: 9,
+                    offset: 278,
+                },
+                end: Pos {
+                    line: 25,
+                    column: 11,
+                    offset: 280,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "c",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 26,
+                            column: 9,
+                            offset: 303,
+                        },
+                        end: Pos {
+                            line: 26,
+                            column: 10,
+                            offset: 304,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 26,
+                    column: 9,
+                    offset: 303,
+                },
+                end: Pos {
+                    line: 26,
+                    column: 10,
+                    offset: 304,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "cc",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 27,
+                            column: 9,
+                            offset: 326,
+                        },
+                        end: Pos {
+                            line: 27,
+                            column: 11,
+                            offset: 328,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 27,
+                    column: 9,
+                    offset: 326,
+                },
+                end: Pos {
+                    line: 27,
+                    column: 11,
+                    offset: 328,
                 },
             },
         },

--- a/src/ast/expects/trait_diag.pi.expect
+++ b/src/ast/expects/trait_diag.pi.expect
@@ -1,6 +1,563 @@
 [
     PLDiag {
         raw: PLDiagRaw {
+            code: Err(
+                PARAMETER_TYPE_NOT_MATCH,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 100,
+                    column: 13,
+                    offset: 1251,
+                },
+                end: Pos {
+                    line: 100,
+                    column: 14,
+                    offset: 1252,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                UNDEFINED_TYPE,
+            ),
+            help: None,
+            labels: [],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 173,
+                    column: 15,
+                    offset: 2475,
+                },
+                end: Pos {
+                    line: 173,
+                    column: 17,
+                    offset: 2477,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                TYPE_MISMATCH,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type `{}`",
+                            [
+                                "A",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 96,
+                            column: 34,
+                            offset: 1163,
+                        },
+                        end: Pos {
+                            line: 96,
+                            column: 35,
+                            offset: 1164,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type `{}`",
+                            [
+                                "generic_trait3<f32>",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 96,
+                            column: 9,
+                            offset: 1138,
+                        },
+                        end: Pos {
+                            line: 96,
+                            column: 11,
+                            offset: 1140,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 96,
+                    column: 34,
+                    offset: 1163,
+                },
+                end: Pos {
+                    line: 96,
+                    column: 35,
+                    offset: 1164,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                TYPE_MISMATCH,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type `{}`",
+                            [
+                                "B<i64>",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 99,
+                            column: 33,
+                            offset: 1236,
+                        },
+                        end: Pos {
+                            line: 99,
+                            column: 34,
+                            offset: 1237,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type `{}`",
+                            [
+                                "generic_trait1<f32>",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 99,
+                            column: 9,
+                            offset: 1212,
+                        },
+                        end: Pos {
+                            line: 99,
+                            column: 10,
+                            offset: 1213,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 99,
+                    column: 33,
+                    offset: 1236,
+                },
+                end: Pos {
+                    line: 99,
+                    column: 34,
+                    offset: 1237,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                EXPECT_TRAIT_TYPE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type {}",
+                            [
+                                "struct",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 177,
+                            column: 6,
+                            offset: 2488,
+                        },
+                        end: Pos {
+                            line: 177,
+                            column: 7,
+                            offset: 2489,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 177,
+                    column: 6,
+                    offset: 2488,
+                },
+                end: Pos {
+                    line: 177,
+                    column: 7,
+                    offset: 2489,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                METHOD_NOT_IN_IMPL,
+            ),
+            help: Some(
+                "add the method to current impl block",
+            ),
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "method {} not in impl block, which is required in trait {}",
+                            [
+                                "name1",
+                                "generic_trait1<T>",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 56,
+                            column: 10,
+                            offset: 608,
+                        },
+                        end: Pos {
+                            line: 56,
+                            column: 24,
+                            offset: 622,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "trait {} def here",
+                            [
+                                "generic_trait1<T>",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 9,
+                            column: 7,
+                            offset: 90,
+                        },
+                        end: Pos {
+                            line: 9,
+                            column: 21,
+                            offset: 104,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 56,
+                    column: 10,
+                    offset: 608,
+                },
+                end: Pos {
+                    line: 56,
+                    column: 24,
+                    offset: 622,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                INVALID_DIRECT_TRAIT_CAST,
+            ),
+            help: Some(
+                "cast a trait to specific type directly is not allowed, use `?` or `!` after the cast expression",
+            ),
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "add `{}` or `{}` to make it legal",
+                            [
+                                "?",
+                                "!",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 105,
+                            column: 21,
+                            offset: 1334,
+                        },
+                        end: Pos {
+                            line: 105,
+                            column: 21,
+                            offset: 1334,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "target type is `{}`",
+                            [
+                                "A",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 105,
+                            column: 20,
+                            offset: 1333,
+                        },
+                        end: Pos {
+                            line: 105,
+                            column: 21,
+                            offset: 1334,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "type of the expression is `{}`",
+                            [
+                                "TestTrait",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 105,
+                            column: 14,
+                            offset: 1327,
+                        },
+                        end: Pos {
+                            line: 105,
+                            column: 16,
+                            offset: 1329,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 105,
+                    column: 14,
+                    offset: 1327,
+                },
+                end: Pos {
+                    line: 105,
+                    column: 21,
+                    offset: 1334,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                DERIVE_TRAIT_NOT_IMPL,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "the derive trait {} not impl",
+                            [
+                                "generic_trait1<T>",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 9,
+                            column: 7,
+                            offset: 90,
+                        },
+                        end: Pos {
+                            line: 9,
+                            column: 21,
+                            offset: 104,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 64,
+                    column: 10,
+                    offset: 672,
+                },
+                end: Pos {
+                    line: 64,
+                    column: 24,
+                    offset: 686,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                THE_TARGET_TRAIT_CANNOT_BE_INSTANTIATED,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "the method `{}` of trait `{}` has generic params, which makes it uninstantiatable",
+                            [
+                                "hash",
+                                "Hash",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 5,
+                            column: 5,
+                            offset: 99,
+                        },
+                        end: Pos {
+                            line: 5,
+                            column: 41,
+                            offset: 135,
+                        },
+                    },
+                },
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "trait type `{}`",
+                            [
+                                "Hash",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 124,
+                            column: 9,
+                            offset: 1811,
+                        },
+                        end: Pos {
+                            line: 124,
+                            column: 17,
+                            offset: 1819,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 124,
+                    column: 9,
+                    offset: 1811,
+                },
+                end: Pos {
+                    line: 124,
+                    column: 17,
+                    offset: 1819,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Warn(
+                UNUSED_VARIABLE,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: "",
+                    txt: Some(
+                        (
+                            "Unused variable `{}`",
+                            [
+                                "hashtest",
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 124,
+                            column: 9,
+                            offset: 1811,
+                        },
+                        end: Pos {
+                            line: 124,
+                            column: 17,
+                            offset: 1819,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 124,
+                    column: 9,
+                    offset: 1811,
+                },
+                end: Pos {
+                    line: 124,
+                    column: 17,
+                    offset: 1819,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
             code: Warn(
                 UNUSED_VARIABLE,
             ),
@@ -139,124 +696,6 @@
     },
     PLDiag {
         raw: PLDiagRaw {
-            code: Err(
-                METHOD_NOT_IN_IMPL,
-            ),
-            help: Some(
-                "add the method to current impl block",
-            ),
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "trait {} def here",
-                            [
-                                "generic_trait1<T>",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 9,
-                            column: 7,
-                            offset: 90,
-                        },
-                        end: Pos {
-                            line: 9,
-                            column: 21,
-                            offset: 104,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "method {} not in impl block, which is required in trait {}",
-                            [
-                                "name1",
-                                "generic_trait1<T>",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 56,
-                            column: 10,
-                            offset: 608,
-                        },
-                        end: Pos {
-                            line: 56,
-                            column: 24,
-                            offset: 622,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 56,
-                    column: 10,
-                    offset: 608,
-                },
-                end: Pos {
-                    line: 56,
-                    column: 24,
-                    offset: 622,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                DERIVE_TRAIT_NOT_IMPL,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "the derive trait {} not impl",
-                            [
-                                "generic_trait1<T>",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 9,
-                            column: 7,
-                            offset: 90,
-                        },
-                        end: Pos {
-                            line: 9,
-                            column: 21,
-                            offset: 104,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 64,
-                    column: 10,
-                    offset: 672,
-                },
-                end: Pos {
-                    line: 64,
-                    column: 24,
-                    offset: 686,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
             code: Warn(
                 UNUSED_VARIABLE,
             ),
@@ -349,8 +788,8 @@
     },
     PLDiag {
         raw: PLDiagRaw {
-            code: Err(
-                TYPE_MISMATCH,
+            code: Warn(
+                UNUSED_VARIABLE,
             ),
             help: None,
             labels: [
@@ -358,9 +797,9 @@
                     file: "",
                     txt: Some(
                         (
-                            "type `{}`",
+                            "Unused variable `{}`",
                             [
-                                "generic_trait3<f32>",
+                                "yy",
                             ],
                         ),
                     ),
@@ -377,365 +816,18 @@
                         },
                     },
                 },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type `{}`",
-                            [
-                                "A",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 96,
-                            column: 34,
-                            offset: 1163,
-                        },
-                        end: Pos {
-                            line: 96,
-                            column: 35,
-                            offset: 1164,
-                        },
-                    },
-                },
             ],
             source: None,
             range: Range {
                 start: Pos {
                     line: 96,
-                    column: 34,
-                    offset: 1163,
-                },
-                end: Pos {
-                    line: 96,
-                    column: 35,
-                    offset: 1164,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                TYPE_MISMATCH,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type `{}`",
-                            [
-                                "generic_trait1<f32>",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 99,
-                            column: 9,
-                            offset: 1212,
-                        },
-                        end: Pos {
-                            line: 99,
-                            column: 10,
-                            offset: 1213,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type `{}`",
-                            [
-                                "B<i64>",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 99,
-                            column: 33,
-                            offset: 1236,
-                        },
-                        end: Pos {
-                            line: 99,
-                            column: 34,
-                            offset: 1237,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 99,
-                    column: 33,
-                    offset: 1236,
-                },
-                end: Pos {
-                    line: 99,
-                    column: 34,
-                    offset: 1237,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                VAR_NOT_FOUND,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 100,
-                    column: 5,
-                    offset: 1243,
-                },
-                end: Pos {
-                    line: 100,
-                    column: 6,
-                    offset: 1244,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                INVALID_DIRECT_TRAIT_CAST,
-            ),
-            help: Some(
-                "cast a trait to specific type directly is not allowed, use `?` or `!` after the cast expression",
-            ),
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type of the expression is `{}`",
-                            [
-                                "TestTrait",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 105,
-                            column: 14,
-                            offset: 1327,
-                        },
-                        end: Pos {
-                            line: 105,
-                            column: 16,
-                            offset: 1329,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "target type is `{}`",
-                            [
-                                "A",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 105,
-                            column: 20,
-                            offset: 1333,
-                        },
-                        end: Pos {
-                            line: 105,
-                            column: 21,
-                            offset: 1334,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "add `{}` or `{}` to make it legal",
-                            [
-                                "?",
-                                "!",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 105,
-                            column: 21,
-                            offset: 1334,
-                        },
-                        end: Pos {
-                            line: 105,
-                            column: 21,
-                            offset: 1334,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 105,
-                    column: 14,
-                    offset: 1327,
-                },
-                end: Pos {
-                    line: 105,
-                    column: 21,
-                    offset: 1334,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                THE_TARGET_TRAIT_CANNOT_BE_INSTANTIATED,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "the method `{}` of trait `{}` has generic params, which makes it uninstantiatable",
-                            [
-                                "hash",
-                                "Hash",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 5,
-                            column: 5,
-                            offset: 99,
-                        },
-                        end: Pos {
-                            line: 5,
-                            column: 41,
-                            offset: 135,
-                        },
-                    },
-                },
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "trait type `{}`",
-                            [
-                                "Hash",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 124,
-                            column: 9,
-                            offset: 1811,
-                        },
-                        end: Pos {
-                            line: 124,
-                            column: 17,
-                            offset: 1819,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 124,
                     column: 9,
-                    offset: 1811,
+                    offset: 1138,
                 },
                 end: Pos {
-                    line: 124,
-                    column: 17,
-                    offset: 1819,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                UNDEFINED_TYPE,
-            ),
-            help: None,
-            labels: [],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 173,
-                    column: 15,
-                    offset: 2475,
-                },
-                end: Pos {
-                    line: 173,
-                    column: 17,
-                    offset: 2477,
-                },
-            },
-        },
-    },
-    PLDiag {
-        raw: PLDiagRaw {
-            code: Err(
-                EXPECT_TRAIT_TYPE,
-            ),
-            help: None,
-            labels: [
-                PLLabel {
-                    file: "",
-                    txt: Some(
-                        (
-                            "type {}",
-                            [
-                                "struct",
-                            ],
-                        ),
-                    ),
-                    range: Range {
-                        start: Pos {
-                            line: 177,
-                            column: 6,
-                            offset: 2488,
-                        },
-                        end: Pos {
-                            line: 177,
-                            column: 7,
-                            offset: 2489,
-                        },
-                    },
-                },
-            ],
-            source: None,
-            range: Range {
-                start: Pos {
-                    line: 177,
-                    column: 6,
-                    offset: 2488,
-                },
-                end: Pos {
-                    line: 177,
-                    column: 7,
-                    offset: 2489,
+                    line: 96,
+                    column: 11,
+                    offset: 1140,
                 },
             },
         },

--- a/src/ast/node/function.rs
+++ b/src/ast/node/function.rs
@@ -934,7 +934,7 @@ impl Node for ClosureNode {
                 typenode.get_type(ctx, builder, true)?
             } else if let Some(id) = v.id {
                 let vv = ctx.unify_table.borrow_mut().probe(id);
-                let tp = vv.get_type(&mut ctx.unify_table.borrow_mut());
+                let tp = vv.get_type(ctx, builder, &mut ctx.unify_table.clone().borrow_mut());
                 if *tp.borrow() == PLType::Unknown {
                     v.range()
                         .new_err(ErrorCode::CLOSURE_PARAM_TYPE_UNKNOWN)
@@ -978,7 +978,7 @@ impl Node for ClosureNode {
             ret.get_type(ctx, builder, true)?
         } else if let Some(ty) = self.ret_id {
             let v = ctx.unify_table.borrow_mut().probe(ty);
-            let tp = v.get_type(&mut ctx.unify_table.borrow_mut());
+            let tp = v.get_type(ctx, builder, &mut ctx.unify_table.clone().borrow_mut());
             tp
         } else if let Some(exp_ty) = &ctx.expect_ty {
             match &*exp_ty.borrow() {

--- a/src/ast/node/function.rs
+++ b/src/ast/node/function.rs
@@ -783,12 +783,14 @@ impl FuncDefNode {
                 let mut infer_ctx = infer_ctx.new_child();
                 infer_ctx.import_symbols(child);
                 infer_ctx.inference_statements(self.body.as_mut().unwrap(), child, builder);
-                let terminator = self
-                    .body
-                    .as_mut()
-                    .expect(&self.id.name)
-                    .emit(child, builder)?
-                    .get_term();
+                let terminator = child.with_diag_src(&child.get_file(), |child| {
+                    Ok(self
+                        .body
+                        .as_mut()
+                        .expect(&self.id.name)
+                        .emit(child, builder)?
+                        .get_term())
+                })?;
                 if !terminator.is_return() && !self.generator {
                     return Err(child.add_diag(
                         self.range

--- a/src/ast/node/function/generator.rs
+++ b/src/ast/node/function/generator.rs
@@ -202,7 +202,7 @@ pub(crate) fn init_generator<'a>(
         modifier: Some((TokenType::PUB, Default::default())),
         body_range: Default::default(),
         is_trait: false,
-        is_tuple: true,
+        is_tuple: false,
         generic_infer_types: Default::default(),
         // generic_infer: Default::default(),
         methods: Default::default(),

--- a/src/ast/node/implement.rs
+++ b/src/ast/node/implement.rs
@@ -44,7 +44,7 @@ impl ImplNode {
                         t.generic_map.clone(),
                     );
                 }
-                Ok(())
+                Ok::<_, PLDiag>(())
             });
         } else {
             let sttp = self.target.get_type(ctx, builder, true)?;

--- a/src/ast/node/node_result.rs
+++ b/src/ast/node/node_result.rs
@@ -114,6 +114,17 @@ pub struct NodeValue {
     receiver: Option<(ValueHandle, Option<Arc<RefCell<PLType>>>)>,
 }
 
+impl Default for NodeValue {
+    fn default() -> Self {
+        Self {
+            value: ValueHandle::default(),
+            ty: Arc::new(RefCell::new(PLType::Unknown)),
+            is_const: false,
+            receiver: None,
+        }
+    }
+}
+
 impl NodeValue {
     pub fn new(value: ValueHandle, ty: Arc<RefCell<PLType>>) -> Self {
         Self {

--- a/src/ast/node/pkg.rs
+++ b/src/ast/node/pkg.rs
@@ -355,6 +355,9 @@ impl ExternIdNode {
         Err(ctx.add_diag(self.range.new_err(ErrorCode::MACRO_NOT_FOUND)))
     }
 
+    /// # solve_mod
+    ///
+    /// 从当前模块开始，解析出该节点对应的符号所在模块
     pub fn solve_mod<'b>(
         &self,
         mut plmod: &'b crate::ast::plmod::Mod,

--- a/src/ast/node/pkg.rs
+++ b/src/ast/node/pkg.rs
@@ -254,14 +254,7 @@ impl Node for ExternIdNode {
             ctx.push_semantic_token(id.range, SemanticTokenType::NAMESPACE, 0);
         }
         let mut plmod = &ctx.plmod;
-        for ns in self.ns.iter() {
-            let re = plmod.submods.get(&ns.get_name(ctx));
-            if let Some(re) = re {
-                plmod = re;
-            } else {
-                return Err(ctx.add_diag(ns.range.new_err(ErrorCode::UNRESOLVED_MODULE)));
-            }
-        }
+        plmod = self.solve_mod(plmod, ctx)?;
         if let Some(symbol) = plmod.get_global_symbol(&self.id.get_name(ctx)) {
             ctx.push_semantic_token(self.id.range, SemanticTokenType::VARIABLE, 0);
             let pltype = symbol.tp.clone();
@@ -360,5 +353,21 @@ impl ExternIdNode {
             return Ok(m.clone());
         }
         Err(ctx.add_diag(self.range.new_err(ErrorCode::MACRO_NOT_FOUND)))
+    }
+
+    pub fn solve_mod<'b>(
+        &self,
+        mut plmod: &'b crate::ast::plmod::Mod,
+        ctx: &Ctx,
+    ) -> Result<&'b crate::ast::plmod::Mod, PLDiag> {
+        for ns in self.ns.iter() {
+            let re = plmod.submods.get(&ns.get_name(ctx));
+            if let Some(re) = re {
+                plmod = re;
+            } else {
+                return Err(ctx.add_diag(ns.range.new_err(ErrorCode::UNRESOLVED_MODULE)));
+            }
+        }
+        Ok(plmod)
     }
 }

--- a/src/ast/node/program.rs
+++ b/src/ast/node/program.rs
@@ -380,6 +380,8 @@ impl Program {
             Hints::push(db, hints);
             let docs = plmod.doc_symbols.borrow().clone();
             DocSymbols::push(db, docs);
+            let b = plmod.semantic_tokens_builder.borrow().build();
+            PLSemanticTokens::push(db, b);
         }
         self.handle_actions(db, p, nn, m);
         m
@@ -499,10 +501,6 @@ impl Program {
                         PLHover::push(db, res.clone());
                     }
                 }
-            }
-            ActionType::SemanticTokensFull => {
-                let b = plmod.semantic_tokens_builder.borrow().build();
-                PLSemanticTokens::push(db, b);
             }
             _ => {}
         }

--- a/src/ast/node/statement.rs
+++ b/src/ast/node/statement.rs
@@ -180,14 +180,14 @@ impl Node for DefNode {
                     }
                 }
             }
-            if self.exp.is_none() && matches!(&*tp.borrow(), PLType::Unknown) {
+            if self.exp.is_none() && !tp.borrow().is_complete() {
                 match builder {
                     #[cfg(feature = "llvm")]
                     BuilderEnum::LLVM(_) => {
                         return Err(ctx.add_diag(
                             self.var
                                 .range()
-                                .new_err(ErrorCode::UNKNOWN_TYPE)
+                                .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
                                 .add_to_ctx(ctx),
                         ));
                     }
@@ -195,7 +195,7 @@ impl Node for DefNode {
                         ctx.add_diag(
                             self.var
                                 .range()
-                                .new_err(ErrorCode::UNKNOWN_TYPE)
+                                .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
                                 .add_to_ctx(ctx),
                         );
                     }

--- a/src/ast/node/statement.rs
+++ b/src/ast/node/statement.rs
@@ -7,6 +7,7 @@ use crate::ast::ctx::Ctx;
 use crate::ast::diag::{ErrorCode, WarnCode};
 use crate::format_label;
 
+use crate::inference::unknown_arc;
 use crate::modifier_set;
 
 use indexmap::IndexMap;
@@ -175,32 +176,16 @@ impl Node for DefNode {
                 if let Some(id) = i.id {
                     let v = ctx.unify_table.borrow_mut().probe(id);
                     tp = v.get_type(ctx, builder, &mut ctx.unify_table.clone().borrow_mut());
-                    if self.exp.is_none() {
-                        ctx.push_type_hints(self.var.range(), tp.clone());
-                    }
                 }
             }
-            if self.exp.is_none() && !tp.borrow().is_complete() {
-                match builder {
-                    #[cfg(feature = "llvm")]
-                    BuilderEnum::LLVM(_) => {
-                        return Err(ctx.add_diag(
-                            self.var
-                                .range()
-                                .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
-                                .add_to_ctx(ctx),
-                        ));
-                    }
-                    BuilderEnum::NoOp(_) => {
-                        ctx.add_diag(
-                            self.var
-                                .range()
-                                .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
-                                .add_to_ctx(ctx),
-                        );
-                    }
-                }
-            }
+            // if self.exp.is_none() && !tp.borrow().is_complete() {
+            //     ctx.add_diag(
+            //         self.var
+            //             .range()
+            //             .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
+            //             .add_to_ctx(ctx),
+            //     );
+            // }
             pltype = Some(tp);
         }
         let mut expv = None;
@@ -215,47 +200,55 @@ impl Node for DefNode {
             pltype = None;
         }
         if let Some(exp) = &mut self.exp {
-            let re = if let Some(pltype) = pltype.clone() {
-                ctx.emit_with_expectation(exp, pltype, self.var.range(), builder)?
-                    .get_value()
+            let re = if let Some(expect) = pltype.clone() {
+                ctx.emit_with_expectation(exp, expect, self.var.range(), builder)
             } else {
-                exp.emit(ctx, builder)?.get_value()
+                exp.emit(ctx, builder)
             };
 
             // for err tolerate
-            if re.is_none() {
-                return Err(ctx.add_diag(self.var.range().new_err(ErrorCode::UNKNOWN_TYPE)));
+            if let Ok(v) = re {
+                if let Some(re) = v.get_value() {
+                    let mut tp = re.get_ty();
+                    let v = if let PLType::Fn(f) = &*tp.clone().borrow() {
+                        let oritp = tp;
+                        let c =
+                            Arc::new(RefCell::new(PLType::Closure(f.to_closure_ty(ctx, builder))));
+                        tp = c.clone();
+                        ctx.up_cast(
+                            c,
+                            oritp,
+                            Default::default(),
+                            Default::default(),
+                            re.get_value(),
+                            builder,
+                        )
+                        .unwrap()
+                    } else {
+                        re.get_value()
+                    };
+                    if self.tp.is_none() && pltype.is_none() {
+                        pltype = Some(tp);
+                    }
+                    expv = Some(v);
+                }
             }
-            let re = re.unwrap();
-            let mut tp = re.get_ty();
-            let v = if let PLType::Fn(f) = &*tp.clone().borrow() {
-                let oritp = tp;
-                let c = Arc::new(RefCell::new(PLType::Closure(f.to_closure_ty(ctx, builder))));
-                tp = c.clone();
-                ctx.up_cast(
-                    c,
-                    oritp,
-                    Default::default(),
-                    Default::default(),
-                    re.get_value(),
-                    builder,
-                )
-                .unwrap()
-            } else {
-                re.get_value()
-            };
-            if pltype.is_none() {
-                ctx.push_type_hints(self.var.range(), tp.clone());
-                pltype = Some(tp);
-            } else if self.tp.is_none() {
-                ctx.push_type_hints(self.var.range(), pltype.clone().unwrap());
-            }
-            expv = Some(v);
         }
-        let pltype = pltype.unwrap();
+        let pltype = pltype.unwrap_or(unknown_arc());
+        if self.tp.is_none() {
+            ctx.push_type_hints(self.var.range(), pltype.clone());
+        }
         let mut gm = IndexMap::new();
         if let PLType::Trait(t) = &*pltype.borrow() {
             gm = t.generic_map.clone();
+        }
+        if !pltype.borrow().is_complete() {
+            ctx.add_diag(
+                self.var
+                    .range()
+                    .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
+                    .add_to_ctx(ctx),
+            );
         }
         ctx.protect_generic_context(&gm, |ctx| {
             handle_deconstruct(

--- a/src/ast/node/statement.rs
+++ b/src/ast/node/statement.rs
@@ -178,14 +178,7 @@ impl Node for DefNode {
                     tp = v.get_type(ctx, builder, &mut ctx.unify_table.clone().borrow_mut());
                 }
             }
-            // if self.exp.is_none() && !tp.borrow().is_complete() {
-            //     ctx.add_diag(
-            //         self.var
-            //             .range()
-            //             .new_err(ErrorCode::TYPE_CANNOT_BE_FULLY_INFERRED)
-            //             .add_to_ctx(ctx),
-            //     );
-            // }
+
             pltype = Some(tp);
         }
         let mut expv = None;

--- a/src/ast/node/statement.rs
+++ b/src/ast/node/statement.rs
@@ -174,7 +174,7 @@ impl Node for DefNode {
             if let DefVar::Identifier(i) = &*self.var {
                 if let Some(id) = i.id {
                     let v = ctx.unify_table.borrow_mut().probe(id);
-                    tp = v.get_type(&mut ctx.unify_table.borrow_mut());
+                    tp = v.get_type(ctx, builder, &mut ctx.unify_table.clone().borrow_mut());
                     if self.exp.is_none() {
                         ctx.push_type_hints(self.var.range(), tp.clone());
                     }

--- a/src/ast/node/tuple.rs
+++ b/src/ast/node/tuple.rs
@@ -45,13 +45,7 @@ impl Node for TupleInitNode {
                     }
                     name.push_str(&tp.get_name());
                     expr_values.push(value);
-                    let f = Field {
-                        index: i as u32 + 1,
-                        typenode: tp.get_typenode(&ctx.get_file()),
-                        name: i.to_string(),
-                        range: Default::default(),
-                        modifier: Some((TokenType::PUB, Default::default())),
-                    };
+                    let f = new_tuple_field(i, &tp, &ctx.get_file());
                     fields.insert(i.to_string(), f);
                 }
                 Err(diag) => {
@@ -63,7 +57,7 @@ impl Node for TupleInitNode {
         if let Some(err) = err {
             return Err(err);
         }
-        let sttype = new_tuple_type(name, ctx, fields, self.range);
+        let sttype = new_tuple_type(name, fields, self.range);
         builder.gen_st_visit_function(ctx, &sttype, &field_tps);
         let stu = Arc::new(RefCell::new(PLType::Struct(sttype)));
         ctx.add_type_without_check(stu.clone());
@@ -84,15 +78,21 @@ impl Node for TupleInitNode {
     }
 }
 
-fn new_tuple_type(
-    name: String,
-    ctx: &mut crate::ast::ctx::Ctx,
-    fields: LinkedHashMap<String, Field>,
-    range: Range,
-) -> STType {
+pub fn new_tuple_field(i: usize, tp: &PLType, f: &str) -> Field {
+    
+    Field {
+        index: i as u32 + 1,
+        typenode: tp.get_typenode(f),
+        name: i.to_string(),
+        range: Default::default(),
+        modifier: Some((TokenType::PUB, Default::default())),
+    }
+}
+
+pub fn new_tuple_type(name: String, fields: LinkedHashMap<String, Field>, range: Range) -> STType {
     STType {
         name,
-        path: ctx.plmod.path.clone(),
+        path: "".to_string(),
         fields,
         range: Default::default(),
         doc: vec![],
@@ -164,7 +164,7 @@ impl TypeNode for TupleTypeNode {
         if let Some(err) = err {
             return Err(err);
         }
-        let sttype = new_tuple_type(name, ctx, fields, self.range);
+        let sttype = new_tuple_type(name, fields, self.range);
         builder.gen_st_visit_function(ctx, &sttype, &field_tps);
         let stu = Arc::new(RefCell::new(PLType::Struct(sttype)));
         ctx.add_type_without_check(stu.clone());

--- a/src/ast/node/tuple.rs
+++ b/src/ast/node/tuple.rs
@@ -79,7 +79,6 @@ impl Node for TupleInitNode {
 }
 
 pub fn new_tuple_field(i: usize, tp: &PLType, f: &str) -> Field {
-    
     Field {
         index: i as u32 + 1,
         typenode: tp.get_typenode(f),

--- a/src/ast/node/types.rs
+++ b/src/ast/node/types.rs
@@ -32,6 +32,9 @@ use lsp_types::SemanticTokenType;
 pub struct TypeNameNode {
     pub id: Option<ExternIdNode>,
     pub generic_params: Option<Box<GenericParamNode>>,
+    /// # generic_infer
+    ///
+    /// Holding inference result of generic parameters.
     pub generic_infer: Option<Vec<TyVariable>>,
 }
 

--- a/src/ast/node/types.rs
+++ b/src/ast/node/types.rs
@@ -20,6 +20,7 @@ use crate::ast::pltype::{ARRType, Field, GenericType, PLType, STType};
 use crate::ast::tokens::TokenType;
 use crate::ast::traits::CustomType;
 use crate::format_label;
+use crate::inference::unknown_arc;
 use crate::inference::TyVariable;
 use indexmap::IndexMap;
 
@@ -303,7 +304,11 @@ impl TypeNode for TypeNameNode {
                     eq: !left.generic_map.iter().any(|(k, l_type)| {
                         !ctx.eq(
                             l_type.clone(),
-                            right.generic_infer_types.get(k).unwrap().clone(),
+                            right
+                                .generic_infer_types
+                                .get(k)
+                                .cloned()
+                                .unwrap_or(unknown_arc()),
                         )
                         .eq
                     }),

--- a/src/ast/node/types.rs
+++ b/src/ast/node/types.rs
@@ -359,6 +359,9 @@ impl TypeNode for ArrayTypeNameNode {
         gen_code: bool,
     ) -> TypeNodeResult {
         let pltype = self.id.get_type(ctx, builder, gen_code)?;
+        if !pltype.borrow().is_complete() {
+            eprintln!("array type not complete {:?}", pltype);
+        }
         let arrtype = ARRType {
             element_type: pltype,
             size_handle: 0,

--- a/src/ast/node/union.rs
+++ b/src/ast/node/union.rs
@@ -44,11 +44,10 @@ impl Node for UnionDefNode {
                 generics.gen_generic_type(ctx)
             });
 
-        _ = ctx.protect_generic_context(&generic_map, |ctx| {
+        ctx.protect_generic_context(&generic_map, |ctx| {
             for tp in self.sum_types.iter_mut() {
                 _ = tp.get_type(ctx, builder, true);
             }
-            Ok(())
         });
         Ok(Default::default())
     }
@@ -71,11 +70,10 @@ impl UnionDefNode {
             .map_or(IndexMap::default(), |generics| {
                 generics.gen_generic_type(ctx)
             });
-        _ = ctx.protect_generic_context(&generic_map, |ctx| {
+        ctx.protect_generic_context(&generic_map, |ctx| {
             if let Some(generics) = self.generics.as_ref() {
-                generics.set_traits(ctx, &generic_map)?;
+                _ = generics.set_traits(ctx, &generic_map);
             }
-            Ok(())
         });
         let stu = Arc::new(RefCell::new(PLType::Union(UnionType {
             name: self.name.name.clone(),

--- a/src/ast/plmod.rs
+++ b/src/ast/plmod.rs
@@ -563,7 +563,7 @@ fn completion_kind(
         PLType::Union(_) => CompletionItemKind::ENUM,
         PLType::Closure(_) => unreachable!(),
         PLType::Unknown => unreachable!(),
-        PLType::PartialInfered(p) => {
+        PLType::PartialInferred(p) => {
             return completion_kind(&p.borrow(), need_snippet, insert_text, command);
         }
     };

--- a/src/ast/plmod.rs
+++ b/src/ast/plmod.rs
@@ -459,29 +459,10 @@ impl Mod {
             if !filter(&f) {
                 continue;
             }
-            let tp = match &*f.clone().borrow() {
-                PLType::Fn(f) => {
-                    if need_snippet {
-                        insert_text = Some(f.gen_snippet());
-                        command = Some(Command::new(
-                            "trigger help".to_string(),
-                            "editor.action.triggerParameterHints".to_string(),
-                            None,
-                        ));
-                    }
-                    CompletionItemKind::FUNCTION
-                }
-                PLType::Struct(_) => CompletionItemKind::STRUCT,
-                PLType::Trait(_) => CompletionItemKind::INTERFACE,
-                PLType::Arr(_) => unreachable!(),
-                PLType::Primitive(_) => CompletionItemKind::KEYWORD,
-                PLType::Generic(_) => CompletionItemKind::TYPE_PARAMETER,
-                PLType::Void => CompletionItemKind::KEYWORD,
-                PLType::Pointer(_) => unreachable!(),
-                PLType::PlaceHolder(_) => continue,
-                PLType::Union(_) => CompletionItemKind::ENUM,
-                PLType::Closure(_) => unreachable!(),
-                PLType::Unknown => unreachable!(),
+            let tp = &*f.borrow();
+            let tp = match completion_kind(tp, need_snippet, &mut insert_text, &mut command) {
+                Some(value) => value,
+                None => continue,
             };
             if k.starts_with('|') {
                 // skip method
@@ -551,6 +532,42 @@ impl Mod {
                 None
             })
     }
+}
+
+fn completion_kind(
+    tp: &PLType,
+    need_snippet: bool,
+    insert_text: &mut Option<String>,
+    command: &mut Option<Command>,
+) -> Option<CompletionItemKind> {
+    let tp = match tp {
+        PLType::Fn(f) => {
+            if need_snippet {
+                *insert_text = Some(f.gen_snippet());
+                *command = Some(Command::new(
+                    "trigger help".to_string(),
+                    "editor.action.triggerParameterHints".to_string(),
+                    None,
+                ));
+            }
+            CompletionItemKind::FUNCTION
+        }
+        PLType::Struct(_) => CompletionItemKind::STRUCT,
+        PLType::Trait(_) => CompletionItemKind::INTERFACE,
+        PLType::Arr(_) => unreachable!(),
+        PLType::Primitive(_) => CompletionItemKind::KEYWORD,
+        PLType::Generic(_) => CompletionItemKind::TYPE_PARAMETER,
+        PLType::Void => CompletionItemKind::KEYWORD,
+        PLType::Pointer(_) => unreachable!(),
+        PLType::PlaceHolder(_) => return None,
+        PLType::Union(_) => CompletionItemKind::ENUM,
+        PLType::Closure(_) => unreachable!(),
+        PLType::Unknown => unreachable!(),
+        PLType::PartialInfered(p) => {
+            return completion_kind(&p.borrow(), need_snippet, insert_text, command);
+        }
+    };
+    Some(tp)
 }
 
 fn get_ns_path_completions_pri(path: &str, vmap: &mut FxHashMap<String, CompletionItem>) {

--- a/src/ast/plmod.rs
+++ b/src/ast/plmod.rs
@@ -534,6 +534,9 @@ impl Mod {
     }
 }
 
+/// # completion_kind
+///
+/// get completion kind from pltype
 fn completion_kind(
     tp: &PLType,
     need_snippet: bool,

--- a/src/ast/pltype.rs
+++ b/src/ast/pltype.rs
@@ -852,7 +852,8 @@ pub struct FnType {
     pub ret_pltype: Box<TypeNodeEnum>,
     pub generic: bool,
     pub modifier: Option<(TokenType, Range)>,
-    pub method: bool,
+    pub st_method: bool,
+    pub trait_method: bool,
     pub generic_map: IndexMap<String, Arc<RefCell<PLType>>>,
     pub generics_size: usize, // the size of generics except the generics from impl node
 }
@@ -1056,7 +1057,7 @@ impl FNValue {
     pub fn gen_snippet(&self) -> String {
         let mut name = self.name.clone();
         let mut iter = self.param_names.iter();
-        if self.fntype.method {
+        if self.fntype.st_method {
             iter.next();
             name = name.split("::").last().unwrap().to_string();
         }
@@ -1071,13 +1072,13 @@ impl FNValue {
     pub fn get_doc_symbol(&self) -> DocumentSymbol {
         #[allow(deprecated)]
         DocumentSymbol {
-            name: if self.fntype.method {
+            name: if self.fntype.st_method {
                 self.name.split("::").last().unwrap().to_string()
             } else {
                 self.name.clone()
             },
             detail: Some(self.get_signature()),
-            kind: if self.fntype.method {
+            kind: if self.fntype.st_method {
                 SymbolKind::METHOD
             } else {
                 SymbolKind::FUNCTION
@@ -1092,7 +1093,7 @@ impl FNValue {
     pub fn get_signature(&self) -> String {
         let mut params = String::new();
         if !self.param_names.is_empty() {
-            if !self.fntype.method {
+            if !self.fntype.st_method {
                 params += &format!(
                     "{}: {}",
                     self.param_names[0],

--- a/src/ast/pltype.rs
+++ b/src/ast/pltype.rs
@@ -16,6 +16,7 @@ use crate::ast::builder::BuilderEnum;
 use crate::format_label;
 use crate::generic_impl;
 use crate::if_not_modified_by;
+use crate::inference::unknown_arc;
 use crate::skip_if_not_modified_by;
 use crate::utils::get_hash_code;
 
@@ -371,6 +372,7 @@ fn new_typename_node(name: &str, range: Range, ns: &[String]) -> Box<TypeNodeEnu
         }),
         generic_params: None,
         range,
+        generic_infer: None,
     }))
 }
 fn new_arrtype_node(typenode: Box<TypeNodeEnum>) -> Box<TypeNodeEnum> {
@@ -1400,7 +1402,11 @@ impl STType {
             let field_pltps = res
                 .fields
                 .values()
-                .map(|f| f.typenode.get_type(ctx, builder, true).unwrap())
+                .map(|f| {
+                    f.typenode
+                        .get_type(ctx, builder, true)
+                        .unwrap_or(unknown_arc())
+                })
                 .collect::<Vec<_>>();
             if !res.is_trait {
                 builder.gen_st_visit_function(ctx, &res, &field_pltps);

--- a/src/ast/pltype.rs
+++ b/src/ast/pltype.rs
@@ -1374,7 +1374,7 @@ impl STType {
             let mut res = self.clone();
             res.name = name;
             ctx.add_type_without_check(Arc::new(RefCell::new(PLType::Struct(res.clone()))));
-            res.fields = self
+            let fields: Result<Vec<_>, _> = self
                 .fields
                 .values()
                 .map(|f| {
@@ -1391,8 +1391,7 @@ impl STType {
                             } else {
                                 f.typenode = f
                                     .typenode
-                                    .get_type(ctx, builder, true)
-                                    .unwrap()
+                                    .get_type(ctx, builder, true)?
                                     .borrow()
                                     .get_typenode(&ctx.get_file());
                             }
@@ -1401,22 +1400,21 @@ impl STType {
                         // eprintln!("{:?}", new_f.ret);
                         new_f.ret = new_f
                             .ret
-                            .get_type(ctx, builder, true)
-                            .unwrap()
+                            .get_type(ctx, builder, true)?
                             .borrow()
                             .get_typenode(&ctx.get_file());
                         nf.typenode = Box::new(TypeNodeEnum::Func(new_f));
                     } else {
                         nf.typenode = f
                             .typenode
-                            .get_type(ctx, builder, true)
-                            .unwrap()
+                            .get_type(ctx, builder, true)?
                             .borrow()
                             .get_typenode(&ctx.get_file());
                     }
-                    (nf.name.clone(), nf)
+                    Ok::<(std::string::String, Field), PLDiag>((nf.name.clone(), nf))
                 })
                 .collect();
+            res.fields = LinkedHashMap::from_iter(fields?);
             let field_pltps = res
                 .fields
                 .values()

--- a/src/ast/pltype.rs
+++ b/src/ast/pltype.rs
@@ -852,6 +852,7 @@ pub struct FnType {
     pub ret_pltype: Box<TypeNodeEnum>,
     pub generic: bool,
     pub modifier: Option<(TokenType, Range)>,
+    /// flag indicating whether the function is a method
     pub st_method: bool,
     pub trait_method: bool,
     pub generic_map: IndexMap<String, Arc<RefCell<PLType>>>,

--- a/src/ast/pltype.rs
+++ b/src/ast/pltype.rs
@@ -69,14 +69,30 @@ pub enum PLType {
     Trait(STType),
     Union(UnionType),
     Closure(ClosureType),
+    /// # Unknown
+    ///
+    /// Unknown type means that the type is not inferred
+    /// or cannot be inferred
     Unknown,
-    PartialInfered(Arc<RefCell<PLType>>),
+    /// # PartialInferred
+    ///
+    /// PartialInfered type is used for type inference
+    ///
+    /// When a type is wrapped by PartialInfered, it means that the type
+    /// is not fully inferred
+    /// e.g. it 'contains' Unknown type
+    PartialInferred(Arc<RefCell<PLType>>),
 }
 
 impl PLType {
+    /// # is_complete
+    ///
+    /// Check if the type is complete
+    ///
+    /// if the type is Unknown or PartialInferred, it is not complete
     pub fn is_complete(&self) -> bool {
         // Unknow/PartialInfered type are not complete
-        !matches!(self, PLType::Unknown | PLType::PartialInfered(_))
+        !matches!(self, PLType::Unknown | PLType::PartialInferred(_))
     }
 }
 
@@ -506,7 +522,7 @@ impl PLType {
             PLType::Union(_) => "union".to_string(),
             PLType::Closure(_) => "closure".to_string(),
             PLType::Unknown => "unknown".to_string(),
-            PLType::PartialInfered(_) => "partial".to_string(),
+            PLType::PartialInferred(_) => "partial".to_string(),
         }
     }
 
@@ -551,7 +567,7 @@ impl PLType {
             PLType::Union(u) => Self::new_custom_tp_node(u, path),
             PLType::Closure(c) => Box::new(c.to_type_node(path)),
             PLType::Unknown => new_typename_node("Unknown", Default::default(), &[]),
-            PLType::PartialInfered(p) => p.borrow().get_typenode(path),
+            PLType::PartialInferred(p) => p.borrow().get_typenode(path),
         }
     }
     pub fn is(&self, pri_type: &PriType) -> bool {
@@ -574,7 +590,7 @@ impl PLType {
             PLType::PlaceHolder(_) => (),
             PLType::Closure(_) => (),
             PLType::Unknown => (),
-            PLType::PartialInfered(p) => p.borrow().if_refs(f, f_local),
+            PLType::PartialInferred(p) => p.borrow().if_refs(f, f_local),
         }
     }
 
@@ -609,7 +625,7 @@ impl PLType {
             PLType::Union(u) => u.name.clone(),
             PLType::Closure(c) => c.get_name(),
             PLType::Unknown => "Unknown".to_string(),
-            PLType::PartialInfered(p) => p.borrow().get_name(),
+            PLType::PartialInferred(p) => p.borrow().get_name(),
         }
     }
     pub fn get_llvm_name(&self) -> String {
@@ -634,7 +650,7 @@ impl PLType {
             PLType::Union(u) => u.name.clone(),
             PLType::Closure(c) => c.get_name(),
             PLType::Unknown => "Unknown".to_string(),
-            PLType::PartialInfered(p) => p.borrow().get_llvm_name(),
+            PLType::PartialInferred(p) => p.borrow().get_llvm_name(),
         }
     }
 
@@ -660,7 +676,7 @@ impl PLType {
             PLType::Union(u) => u.get_full_name(),
             PLType::Closure(c) => c.get_name(),
             PLType::Unknown => "Unknown".to_string(),
-            PLType::PartialInfered(p) => p.borrow().get_full_elm_name(),
+            PLType::PartialInferred(p) => p.borrow().get_full_elm_name(),
         }
     }
     pub fn get_full_elm_name_without_generic(&self) -> String {
@@ -679,7 +695,7 @@ impl PLType {
             PLType::Union(u) => u.get_full_name_except_generic(),
             PLType::Closure(c) => c.get_name(),
             PLType::Unknown => "Unknown".to_string(),
-            PLType::PartialInfered(p) => p.borrow().get_full_elm_name_without_generic(),
+            PLType::PartialInferred(p) => p.borrow().get_full_elm_name_without_generic(),
         }
     }
     pub fn get_ptr_depth(&self) -> usize {
@@ -704,7 +720,7 @@ impl PLType {
                 if_not_modified_by!(st.modifier, TokenType::PUB, return false);
                 true
             }
-            PLType::PartialInfered(p) => p.borrow().is_pub(),
+            PLType::PartialInferred(p) => p.borrow().is_pub(),
             _ => true,
         }
     }
@@ -760,7 +776,7 @@ impl PLType {
                 );
                 Ok(())
             }
-            PLType::PartialInfered(p) => p.borrow().expect_pub(ctx, range),
+            PLType::PartialInferred(p) => p.borrow().expect_pub(ctx, range),
             _ => Ok(()),
         }
     }
@@ -781,7 +797,7 @@ impl PLType {
             PLType::Union(u) => Some(u.range),
             PLType::Closure(c) => Some(c.range),
             PLType::Unknown => None,
-            PLType::PartialInfered(p) => p.borrow().get_range(),
+            PLType::PartialInferred(p) => p.borrow().get_range(),
         }
     }
 

--- a/src/ast/pltype/method.rs
+++ b/src/ast/pltype/method.rs
@@ -96,6 +96,7 @@ pub trait TraitImplAble {
 pub trait Generic {
     fn get_generic_map(&self) -> &IndexMap<String, Arc<RefCell<PLType>>>;
     fn get_generic_infer_map(&self) -> Option<&IndexMap<String, Arc<RefCell<PLType>>>>;
+    fn get_generic_size(&self) -> usize;
 }
 
 impl Generic for STType {
@@ -106,6 +107,24 @@ impl Generic for STType {
     fn get_generic_infer_map(&self) -> Option<&IndexMap<String, Arc<RefCell<PLType>>>> {
         Some(&self.generic_infer_types)
     }
+
+    fn get_generic_size(&self) -> usize {
+        self.generic_map.len()
+    }
+}
+
+impl Generic for FNValue {
+    fn get_generic_map(&self) -> &IndexMap<String, Arc<RefCell<PLType>>> {
+        &self.fntype.generic_map
+    }
+
+    fn get_generic_infer_map(&self) -> Option<&IndexMap<String, Arc<RefCell<PLType>>>> {
+        None
+    }
+
+    fn get_generic_size(&self) -> usize {
+        self.fntype.generics_size
+    }
 }
 
 impl Generic for UnionType {
@@ -115,6 +134,10 @@ impl Generic for UnionType {
 
     fn get_generic_infer_map(&self) -> Option<&IndexMap<String, Arc<RefCell<PLType>>>> {
         None
+    }
+
+    fn get_generic_size(&self) -> usize {
+        self.generic_map.len()
     }
 }
 

--- a/src/ast/pltype/method.rs
+++ b/src/ast/pltype/method.rs
@@ -93,9 +93,17 @@ pub trait TraitImplAble {
     }
 }
 
+/// # Generic
+///
+/// Describe a type that has generic parameters.
 pub trait Generic {
     fn get_generic_map(&self) -> &IndexMap<String, Arc<RefCell<PLType>>>;
     fn get_generic_infer_map(&self) -> Option<&IndexMap<String, Arc<RefCell<PLType>>>>;
+    /// # get_generic_size
+    /// Although in most cases, the size of generic_map
+    /// is equal to the generic_size, but in method impl
+    /// of a generic type, the generic_size is the size
+    /// generic_map of plus 1
     fn get_generic_size(&self) -> usize;
 }
 

--- a/src/ast/test.rs
+++ b/src/ast/test.rs
@@ -695,4 +695,5 @@ pub(crate) fn set_test_asset() {
         .unwrap();
     let timestamp_nanos = duration_since_epoch.as_nanos(); // u128
     *p = format!("target/test{}", timestamp_nanos);
+    std::fs::create_dir_all(&*p).unwrap();
 }

--- a/src/ast/test.rs
+++ b/src/ast/test.rs
@@ -28,8 +28,6 @@ use crate::{
     Db,
 };
 
-use super::range::Range;
-
 fn test_lsp<'db, A>(
     db: &'db dyn Db,
     params: Option<(Pos, Option<String>)>,
@@ -101,39 +99,11 @@ fn sanitize_diag(diag: &[super::diag::PLDiag]) -> Vec<super::diag::PLDiag> {
             d
         })
         .collect::<Vec<_>>();
-    diag.sort_by(sort());
-    diag.iter_mut()
-        .for_each(|d| d.raw.labels.sort_by(sort_lable()));
+    diag.sort();
+    diag.iter_mut().for_each(|d| d.raw.labels.sort());
     diag
 }
 
-fn sort() -> impl Fn(&super::diag::PLDiag, &super::diag::PLDiag) -> std::cmp::Ordering {
-    |a, b| compare_range(a.raw.range, b.raw.range)
-}
-
-fn compare_range(l: Range, r: Range) -> std::cmp::Ordering {
-    if compare_pos(l.start, r.start) == std::cmp::Ordering::Less {
-        std::cmp::Ordering::Less
-    } else if compare_pos(l.start, r.start) == std::cmp::Ordering::Equal {
-        compare_pos(l.end, r.end)
-    } else {
-        std::cmp::Ordering::Greater
-    }
-}
-
-fn compare_pos(l: Pos, r: Pos) -> std::cmp::Ordering {
-    if l.line < r.line || (l.line == r.line && l.column < r.column) {
-        std::cmp::Ordering::Less
-    } else if l.line == r.line && l.column == r.column {
-        std::cmp::Ordering::Equal
-    } else {
-        std::cmp::Ordering::Greater
-    }
-}
-
-fn sort_lable() -> impl Fn(&super::diag::PLLabel, &super::diag::PLLabel) -> std::cmp::Ordering {
-    |a, b| compare_range(a.range, b.range)
-}
 #[test]
 fn test_memory_leak() {
     let db = &mut Database::default();

--- a/src/ast/test.rs
+++ b/src/ast/test.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
 use std::{
-    cell::RefCell,
     fs::remove_file,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -51,7 +50,7 @@ where
     // let db = Database::default();
     let input = MemDocsInput::new(
         db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         src.to_string(),
         Default::default(),
         action,
@@ -156,7 +155,7 @@ fn test_memory_leak() {
     // let db = Database::default();
     let input = MemDocsInput::new(
         db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         "test/lsp/mod.pi".to_string(),
         Default::default(),
         ActionType::FindReferences,
@@ -170,12 +169,11 @@ fn test_memory_leak() {
         .to_str()
         .unwrap()
         .to_string();
-    input.docs(db).lock().unwrap().borrow_mut().change(
-        db,
-        new_diag_range(0, 0, 0, 0),
-        path,
-        "\n".repeat(2),
-    );
+    input
+        .docs(db)
+        .lock()
+        .unwrap()
+        .change(db, new_diag_range(0, 0, 0, 0), path, "\n".repeat(2));
     input.set_action(db).to(ActionType::Diagnostic);
     input.set_params(db).to(Some((
         Pos {
@@ -514,7 +512,7 @@ fn test_jit() {
     let db = Database::default();
     let input = MemDocsInput::new(
         &db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         "test/main.pi".to_string(),
         Default::default(),
         ActionType::Compile,
@@ -564,7 +562,7 @@ fn test_compile() {
     let db = Database::default();
     let input = MemDocsInput::new(
         &db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         "test/main.pi".to_string(),
         Default::default(),
         ActionType::Compile,
@@ -610,7 +608,7 @@ fn test_printast() {
     let db = Database::default();
     let input = MemDocsInput::new(
         &db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         "test/main.pi".to_string(),
         Default::default(),
         ActionType::PrintAst,
@@ -647,7 +645,7 @@ fn test_lsp_incremental() {
     let docs = MemDocs::default();
     let input = MemDocsInput::new(
         db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         "test/lsp_incremental/main.pi".to_string(),
         Default::default(),
         ActionType::Diagnostic,
@@ -680,7 +678,7 @@ fn test_tail_call_opt() {
     let db = Database::default();
     let input = MemDocsInput::new(
         &db,
-        Arc::new(Mutex::new(RefCell::new(docs))),
+        Arc::new(Mutex::new(docs)),
         "test/tail/main.pi".to_string(),
         Default::default(),
         ActionType::Compile,

--- a/src/db.rs
+++ b/src/db.rs
@@ -21,7 +21,7 @@ pub struct Database {
     //
     logs: Option<Arc<Mutex<Vec<String>>>>,
     ref_str: Arc<Mutex<Cell<Option<String>>>>,
-    module_map: Arc<Mutex<RefCell<FxHashMap<String, Mod>>>>,
+    module_map: Arc<Mutex<FxHashMap<String, Mod>>>,
 }
 // ANCHOR_END: db_struct
 
@@ -64,22 +64,17 @@ impl Db for Database {
     }
 
     fn add_module(&self, name: String, plmod: Mod) {
-        self.module_map
-            .lock()
-            .unwrap()
-            .borrow_mut()
-            .insert(name, plmod);
+        self.module_map.lock().unwrap().insert(name, plmod);
     }
 
     fn get_module(&self, name: &str) -> Option<Mod> {
-        self.module_map.lock().unwrap().borrow().get(name).cloned()
+        self.module_map.lock().unwrap().get(name).cloned()
     }
 
     fn add_tp_to_mod(&self, name: &str, tpname: &str, pltype: Arc<RefCell<PLType>>) {
         self.module_map
             .lock()
             .unwrap()
-            .borrow_mut()
             .get_mut(name)
             .and_then(|m| m.types.insert(tpname.to_string(), pltype.into()));
     }

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -392,17 +392,6 @@ impl<'ctx> InferenceCtx<'ctx> {
             (TyInfer::Term(t), TyInfer::Generic(_)) => {
                 self.unify_var_tp(v2, t, ctx, builder);
             }
-            // (TyInfer::Pointer(t1), TyInfer::Pointer(t2)) => {
-            //     self.handle_unify(t1, t2, ctx, builder);
-            // }
-            // (TyInfer::Term(t), TyInfer::Pointer(p)) | (TyInfer::Pointer(p), TyInfer::Term(t)) => {
-            //     match &*t.borrow() {
-            //         PLType::Pointer(ptr_ty) => {
-            //             self.unify_var_tp(p, ptr_ty.clone(), ctx, builder);
-            //         }
-            //         _ => (),
-            //     }
-            // }
             _ => (),
         };
         _ = self.unify_table.borrow_mut().unify_var_var(v, v2);
@@ -468,6 +457,17 @@ impl<'ctx> InferenceCtx<'ctx> {
                 .unify_var_value(key, TyInfer::Term(ty.pltype.clone()));
             self.add_symbol(name, key);
         }
+    }
+
+    pub fn set_fn_ret_tp<'a, 'b>(
+        &mut self,
+        tp: Arc<RefCell<PLType>>,
+        ctx: &'b mut Ctx<'a>,
+        builder: &'b BuilderEnum<'a, '_>,
+    ) {
+        let new_id = self.new_key();
+        self.unify_var_tp(new_id, tp, ctx, builder);
+        self.add_symbol("@ret", new_id);
     }
 
     #[allow(dead_code)]

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -37,7 +37,7 @@ use crate::ast::{
         pointer::PointerOpEnum,
         statement::{DefVar, StatementsNode},
         tuple::{new_tuple_field, new_tuple_type},
-        types::TypeNameNode,
+        types::{GenericParamNode, TypeNameNode},
         NodeEnum, TypeNode, TypeNodeEnum,
     },
     pltype::{get_type_deep, ARRType, ClosureType, ImplAble, PLType, STType, TraitImplAble},
@@ -47,6 +47,11 @@ use crate::ast::{
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TyVariable {
     id: u32,
+}
+
+pub trait GenericInferenceAble {
+    fn get_inference_result(&self) -> &Option<Vec<TyVariable>>;
+    fn get_generic_params(&self) -> &Option<Box<GenericParamNode>>;
 }
 
 impl UnifyKey for TyVariable {
@@ -228,7 +233,7 @@ impl TyInfer {
                             st.gen_code(ctx, builder).unwrap_or(unknown_arc())
                         });
                         if partial {
-                            return new_arc_refcell(PLType::PartialInfered(st));
+                            return new_arc_refcell(PLType::PartialInferred(st));
                         }
                         st
                     }
@@ -237,7 +242,7 @@ impl TyInfer {
                         let infer = unify_table.probe(p);
                         let ty = infer.get_type(ctx, builder, unify_table);
                         if !ty.borrow().is_complete() {
-                            return new_arc_refcell(PLType::PartialInfered(Arc::new(
+                            return new_arc_refcell(PLType::PartialInferred(Arc::new(
                                 RefCell::new(PLType::Arr(ARRType {
                                     element_type: ty,
                                     size_handle: 0,
@@ -251,7 +256,7 @@ impl TyInfer {
                         let infer = unify_table.probe(p);
                         let ty = infer.get_type(ctx, builder, unify_table);
                         if !ty.borrow().is_complete() {
-                            return new_arc_refcell(PLType::PartialInfered(Arc::new(
+                            return new_arc_refcell(PLType::PartialInferred(Arc::new(
                                 RefCell::new(PLType::Arr(ARRType {
                                     element_type: ty,
                                     size_handle: 0,

--- a/src/lsp/dispatcher.rs
+++ b/src/lsp/dispatcher.rs
@@ -15,6 +15,7 @@ impl Dispatcher {
         if let Message::Request(req) = self.0.clone() {
             let params = cast::<R>(req).map_err(|_| ());
             if let Ok(params) = params {
+                log::info!("req: {}", R::METHOD);
                 f(params.0, params.1);
             }
         }
@@ -29,6 +30,7 @@ impl Dispatcher {
         if let Message::Notification(req) = self.0.clone() {
             let params = cast_noti::<R>(req).map_err(|_| ());
             if let Ok(params) = params {
+                log::info!("noti: {}", R::METHOD);
                 f(params);
             }
         }

--- a/src/lsp/lspserver.rs
+++ b/src/lsp/lspserver.rs
@@ -4,6 +4,7 @@ use std::{
     ops::Deref,
     sync::{Arc, Mutex},
     thread::available_parallelism,
+    time::Instant,
 };
 
 use log::debug;
@@ -140,7 +141,7 @@ fn main_loop(
 
     log::info!("starting main loop");
     for msg in &connection.receiver {
-        // let now = Instant::now();
+        let now = Instant::now();
         let di = Dispatcher::new(msg.clone());
         if let Message::Request(req) = &msg {
             if connection.handle_shutdown(req)? {
@@ -485,6 +486,7 @@ fn main_loop(
                 }
                 guard.1 = None;
                 guard.0 = comps;
+                drop(guard);
                 let diags = compile_dry::accumulated::<Diagnostics>(snapshot.deref(), docin);
                 debug!("diags: {:#?}", diags);
                 let mut m = FxHashMap::<String, Vec<Diagnostic>>::default();
@@ -528,7 +530,8 @@ fn main_loop(
             // docs.lock().unwrap().borrow_mut().remove(&f);
             // docin.set_docs(&mut db).to(docs.clone());
         });
-        // let elapsed = now.elapsed();
+        let elapsed = now.elapsed();
+        log::info!("main loop handle message: {:?}", elapsed);
     }
     Ok(())
 }

--- a/src/lsp/wasm.rs
+++ b/src/lsp/wasm.rs
@@ -56,7 +56,7 @@ lazy_static! {
     static ref DOCIN: MemDocsInput = {
         let b = &DB.inner;
         let db = b.borrow_mut();
-        let docs = Arc::new(Mutex::new(RefCell::new(MemDocs::default())));
+        let docs = Arc::new(Mutex::new(MemDocs::default()));
         let doc = MemDocsInput::new(
             &*db,
             docs.clone(),
@@ -87,7 +87,7 @@ pub unsafe fn on_change_doc(req: &str) -> String {
     // let mut completions: Vec<Vec<lsp_types::CompletionItem>> = vec![];
     let f = url_to_path(params.text_document.uri);
     for content_change in params.content_changes.iter() {
-        docs.lock().unwrap().borrow_mut().change(
+        docs.lock().unwrap().change(
             db,
             content_change.range.unwrap(),
             f.clone(),
@@ -139,16 +139,15 @@ pub unsafe fn on_change_doc(req: &str) -> String {
 
 pub static PLLIB_DIR: Dir = include_dir!("./planglib");
 
-fn add_file(db: &mut Database, docs: Arc<Mutex<RefCell<MemDocs>>>, fpath: &str, content: &str) {
+fn add_file(db: &mut Database, docs: Arc<Mutex<MemDocs>>, fpath: &str, content: &str) {
     // include!(real_path);
     // log::error!("add file: {}", fpath);
     docs.lock()
         .unwrap()
-        .borrow_mut()
         .insert(db, fpath.into(), content.into(), fpath.into());
 }
 
-fn add_fill_rec(db: &mut Database, docs: Arc<Mutex<RefCell<MemDocs>>>, dir: &Dir) {
+fn add_fill_rec(db: &mut Database, docs: Arc<Mutex<MemDocs>>, dir: &Dir) {
     dir.files().for_each(|f| {
         let path = f.path();
         f.contents_utf8().map(|x| {
@@ -160,7 +159,7 @@ fn add_fill_rec(db: &mut Database, docs: Arc<Mutex<RefCell<MemDocs>>>, dir: &Dir
     });
 }
 
-fn add_pl_libs(db: &mut Database, docs: Arc<Mutex<RefCell<MemDocs>>>) {
+fn add_pl_libs(db: &mut Database, docs: Arc<Mutex<MemDocs>>) {
     for entry in PLLIB_DIR.dirs() {
         let path = entry.path();
         if path.starts_with("thirdparty") {
@@ -179,13 +178,13 @@ pub fn set_init_content(content: &str) -> String {
     let binding = &DB.inner;
     let db = &mut *binding.borrow_mut();
     let docs = docin.docs(db);
-    docs.lock().unwrap().borrow_mut().insert(
+    docs.lock().unwrap().insert(
         db,
         LSP_DEMO_URI.to_string(),
         content.to_string(),
         LSP_DEMO_URI.to_string(),
     );
-    docs.lock().unwrap().borrow_mut().insert(
+    docs.lock().unwrap().insert(
         db,
         LSP_DEMO_CONF_URI.to_string(),
         r#"entry = "http://www.test.com/main.pi"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ mod nomparser;
 mod utils;
 mod version;
 use std::{
-    cell::RefCell,
     path::Path,
     process::exit,
     sync::{Arc, Mutex},
@@ -177,7 +176,7 @@ impl Cli {
 
         let mem = MemDocsInput::new(
             &db,
-            Arc::new(Mutex::new(RefCell::new(mem_docs::MemDocs::default()))),
+            Arc::new(Mutex::new(mem_docs::MemDocs::default())),
             abs.to_str().unwrap().to_string(),
             op,
             action,
@@ -256,7 +255,7 @@ impl Cli {
 
         let mem = MemDocsInput::new(
             &db,
-            Arc::new(Mutex::new(RefCell::new(mem_docs::MemDocs::default()))),
+            Arc::new(Mutex::new(mem_docs::MemDocs::default())),
             abs.to_str().unwrap().to_string(),
             op,
             action,

--- a/src/nomparser/expression.rs
+++ b/src/nomparser/expression.rs
@@ -215,6 +215,7 @@ pub fn complex_exp(input: Span) -> IResult<Span, Box<NodeEnum>> {
                                 callee: res,
                                 paralist: args,
                                 comments: vec![op.1],
+                                generic_infer: None,
                             }
                             .into(),
                         )

--- a/src/nomparser/identifier.rs
+++ b/src/nomparser/identifier.rs
@@ -118,6 +118,7 @@ pub fn typed_identifier(input: Span) -> IResult<Span, Box<TypedIdentifierNode>> 
                 id: None,
                 range: tprange,
                 generic_params: None,
+                generic_infer: None,
             }));
 
             let mut doc = None;

--- a/src/nomparser/types.rs
+++ b/src/nomparser/types.rs
@@ -57,6 +57,7 @@ pub fn basic_type(input: Span) -> IResult<Span, Box<TypeNodeEnum>> {
                 generic_params,
                 id: Some(exid),
                 range,
+                generic_infer: None,
             })))
         },
     ))(input)

--- a/src/utils/plc_new.rs
+++ b/src/utils/plc_new.rs
@@ -67,10 +67,8 @@ pub mod tests {
     use crate::db::Database;
     use crate::lsp::mem_docs::{self, MemDocsInput};
     use std::fs::remove_file;
-    use std::{
-        cell::RefCell,
-        sync::{Arc, Mutex},
-    };
+    use std::sync::Arc;
+    use std::sync::Mutex;
 
     #[test]
     fn test_init_package() {
@@ -100,7 +98,7 @@ pub mod tests {
 
         let input = MemDocsInput::new(
             &db,
-            Arc::new(Mutex::new(RefCell::new(mem_docs::MemDocs::default()))),
+            Arc::new(Mutex::new(mem_docs::MemDocs::default())),
             "plc_new_testfile/main.pi".to_string(),
             Default::default(),
             ActionType::Compile,

--- a/test/Kagari.toml
+++ b/test/Kagari.toml
@@ -4,4 +4,4 @@ entry = "main.pi"
 
 [deps]
 project2 = { path = "project2" }
-pl_test = { git = "https://github.com/Pivot-Studio/pl_test.git", head = "main" }
+# pl_test = { git = "https://github.com/Pivot-Studio/pl_test.git", head = "main" }

--- a/test/main.pi
+++ b/test/main.pi
@@ -20,7 +20,7 @@ use project1::test::map;
 use project1::test::tree;
 use project1::test::fixed_point;
 use project1::tmod2;
-use pl_test::main;
+// use pl_test::main;
 use project1::test::deconstruct;
 use project1::test::st::*;
 use project1::test::arr;
@@ -45,7 +45,7 @@ pub fn main() i64 {
     simple::test_simple();
     flow::test_flow();
     list::test_list();
-    main::simple_test();
+    // main::simple_test();
     module::test_module();
     str::test_string();
     union::test_union();

--- a/test/main.pi
+++ b/test/main.pi
@@ -34,6 +34,7 @@ use project1::test::futuretest;
 use core::hash::pl_hash::*;
 
 pub fn main() i64 {
+
     macros::test_macros();
     ifel::test_if_else();
     generic::test_generic();

--- a/test/main.pi
+++ b/test/main.pi
@@ -98,6 +98,9 @@ pub fn main() i64 {
     i_table.insert(3, 4);
     let one =  i_table.get(1) as i64!;
     let three = i_table.get(3) as i64!;
+    let hasher;
+    hasher = new_paul_larson_hasher(1 as u64);
+    three.hash(&hasher);
     println!(one);
     println!(three);
     let attt = 1;

--- a/test/main.pi
+++ b/test/main.pi
@@ -32,6 +32,7 @@ use project1::test::inference;
 use project1::test::futuretest;
 
 use core::hash::pl_hash::*;
+// use std::cols::hashtable::new_hash_table;
 
 pub fn main() i64 {
 
@@ -72,9 +73,11 @@ pub fn main() i64 {
     fd.close();
     
     arr::test_arr();
+    let table1 = hashtable::new_hash_table(10 as u64, 100 as u64);
+    table1.insert(1, "");
 
-
-    let table = hashtable::new_hash_table<string|string>(10 as u64, 100 as u64);
+    let table;
+    table = hashtable::new_hash_table(10 as u64, 100 as u64);
     table.insert("hi", "World");
     table.insert("tj", "love hj");
     let v = table.get("hi") as string!;
@@ -89,8 +92,8 @@ pub fn main() i64 {
         str.append("1");
         table.insert(str, "World2");
     }
-    println!(table.bucket_size());
-    let i_table = hashtable::new_hash_table<i64|i64>(10 as u64, 100 as u64);
+    // println!(table.bucket_size());
+    let i_table = hashtable::new_hash_table(10 as u64, 100 as u64);
     i_table.insert(1, 2);
     i_table.insert(3, 4);
     let one =  i_table.get(1) as i64!;

--- a/test/test/fixed_point.pi
+++ b/test/test/fixed_point.pi
@@ -25,12 +25,12 @@ impl<A|F> Func<A|F> {
 }
 
 fn Y<A|R>(g: ||A| => R, A| => R) |A| => R {
-    return |x: A| => R {
-        return |f: Func<A|R>, x: A| => R {
+    return |x| => {
+        return |f, x| => {
             return f.call(f, x);
         }(Func{
-            f: |f: Func<A|R>, x: A| => R {
-                return g(|x| =>  {
+            f: |f, x| => {
+                return g(|x| => {
                     return f.call(f, x);
                 }, x);
             }

--- a/test/test/generic.pi
+++ b/test/test/generic.pi
@@ -136,8 +136,11 @@ pub fn test_generic_same_name() void {
 }
 
 pub fn test_ret_generic<T>() void {
-    let x = ret_generic1<i64>();
-    let y = ret_generic2(true);
+    let x;
+    x = ret_generic1<i64>();
+    let yy ;
+    yy = true;
+    let y = ret_generic2(yy);
     let z = ret_generic2([1, 2, 3]);
     let i = ret_generic2(&z);
     x.c.b.a = 999;

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -72,6 +72,14 @@ fn test_inference_no_run() void {
     let ad7 = st3{};
     ad7.c[0] = &e ;
     e = 10;
+    let a;
+    param_reference(a);
+    a.a = 1;
+    let c;
+    let b;
+    b = ret_reference(c);
+    b.test("adsada");
+
     return;
 }
 
@@ -139,3 +147,12 @@ impl <T> st<T> {
     }
 }
 
+
+fn param_reference<T>(s:st<T>) T {
+    return s.a;
+}
+
+
+fn ret_reference<T>(a:T) st<T> {
+    return st<T>{};
+}

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -30,7 +30,7 @@ pub fn test_inference() void {
 fn test_generic_inference() void {
     let ad ;
     ad = st {};
-    ad.a = 1;
+    ad.a = 100;
 
     let ad2;
     ad2 = st2 {};
@@ -96,6 +96,14 @@ fn test_deconstruct_inference() void {
         return c;
     };
     f = func(d,e);
+    let g;
+    g = generic_f(1);
+    let dddd;
+
+    let eeee ;
+    dddd = st{};
+    eeee = dddd.test(eeee);
+    eeee = 1;
     return;
 }
 
@@ -104,6 +112,11 @@ fn test_f_infer(x:i32) i128 {
     return x as i128;
 }
 
+
+fn generic_f<T>(a:T) T {
+    
+    return a;
+}
 
 struct t {
     a:i16;
@@ -118,4 +131,11 @@ struct st2<T|TT> {
     b:TT;
 }
 
+
+impl <T> st<T> {
+    fn test(t:T) T {
+        
+        return self.a;
+    }
+}
 

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -119,9 +119,6 @@ fn test_deconstruct_inference() void {
     let aadsadsa;
     aadsadsa = adc;
 
-    let yuyudsyfsui;
-    aadsadsa.eq(yuyudsyfsui);
-
     
     return;
 }

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -36,6 +36,19 @@ fn test_generic_inference() void {
     ad2 = st2 {};
     ad2.taaa.a = 1;
     ad2.b = 2.0;
+    let ad3;
+    ad3 = st3 {};
+    let b;
+    ad3.a = &b;
+    b = 1;
+    let f = |a| => {
+        return;
+    };
+    // let ad4 = ad3{};
+    // ad4.d = f;
+
+    f(1);
+
 
     return;
 }
@@ -73,4 +86,9 @@ struct st<T> {
 struct st2<T|TT> {
     taaa:st<T>;
     b:TT;
+}
+
+struct st3<TB> {
+    a:*TB;
+    d:|TB|=>void;
 }

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -22,7 +22,24 @@ pub fn test_inference() void {
     yy = ~y;
     let xx ;
     xx = &(~y);
+    test_deconstruct_inference();
 
+    return;
+}
+
+fn test_deconstruct_inference() void {
+    let a;
+    let b;
+    let c;
+    let d;
+    let e;
+    let f;
+    (a,(b,c)) = (d,(e,f));
+    let func = |a,b|=> {
+        let c = a + b + 1;
+        return c;
+    };
+    f = func(d,e);
     return;
 }
 

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -49,6 +49,29 @@ fn test_generic_inference() void {
     let ad4 = st3{};
     ad4.d = f;
     f(1);
+
+    let c  ;
+    let ad5 = st3{};
+    c = [&b];
+    ad5.c = c;
+
+
+
+    let d;
+    let ad6 = st3{};
+    ad6.e = d;
+    d = (1,2);
+    
+
+    return;
+}
+
+
+fn test_inference_no_run() void {
+    let e;
+    let ad7 = st3{};
+    ad7.c[0] = &e ;
+    e = 10;
     return;
 }
 
@@ -56,6 +79,8 @@ fn test_generic_inference() void {
 struct st3<TB> {
     a:*TB;
     d:|TB|=>void;
+    c:[*TB];
+    e:(TB, TB);
 }
 
 fn test_deconstruct_inference() void {

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -41,16 +41,21 @@ fn test_generic_inference() void {
     let b;
     ad3.a = &b;
     b = 1;
-    let f = |a| => {
+    
+    let f ;
+    f = |a| => {
         return;
     };
-    // let ad4 = ad3{};
-    // ad4.d = f;
-
+    let ad4 = st3{};
+    ad4.d = f;
     f(1);
-
-
     return;
+}
+
+
+struct st3<TB> {
+    a:*TB;
+    d:|TB|=>void;
 }
 
 fn test_deconstruct_inference() void {
@@ -88,7 +93,4 @@ struct st2<T|TT> {
     b:TT;
 }
 
-struct st3<TB> {
-    a:*TB;
-    d:|TB|=>void;
-}
+

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -23,6 +23,19 @@ pub fn test_inference() void {
     let xx ;
     xx = &(~y);
     test_deconstruct_inference();
+    test_generic_inference();
+    return;
+}
+
+fn test_generic_inference() void {
+    let ad ;
+    ad = st {};
+    ad.a = 1;
+
+    let ad2;
+    ad2 = st2 {};
+    ad2.taaa.a = 1;
+    ad2.b = 2.0;
 
     return;
 }
@@ -51,4 +64,13 @@ fn test_f_infer(x:i32) i128 {
 
 struct t {
     a:i16;
+}
+
+struct st<T> {
+    a:T;
+}
+
+struct st2<T|TT> {
+    taaa:st<T>;
+    b:TT;
 }

--- a/test/test/inference.pi
+++ b/test/test/inference.pi
@@ -91,6 +91,7 @@ struct st3<TB> {
     e:(TB, TB);
 }
 
+use core::eq::Eq;
 fn test_deconstruct_inference() void {
     let a;
     let b;
@@ -112,6 +113,16 @@ fn test_deconstruct_inference() void {
     dddd = st{};
     eeee = dddd.test(eeee);
     eeee = 1;
+    let fhjkdshfjdks ;
+    eeee.eq(&fhjkdshfjdks);
+    let adc:Eq<i64> = eeee;
+    let aadsadsa;
+    aadsadsa = adc;
+
+    let yuyudsyfsui;
+    aadsadsa.eq(yuyudsyfsui);
+
+    
     return;
 }
 


### PR DESCRIPTION
This is very much a work in progress, hopefully this pr will implement following inference logic:

- [x] tuple type inference
- [x] generic type inference
    - [x] basic field inference
    - [x] pointer field inference
    - [x] array field inference
    - [x] closure field inference
    - [x] tuple field inference
- [x] generic function inference
    - [x] ordinary function inference
    - [x] method inference 
- [x] some lsp improvements

close #347 

close #370 