### PR TITLE
fix: wrong inlay hint pos & ambigious def jump

### DIFF
--- a/src/ast/expects/hinttest.expect
+++ b/src/ast/expects/hinttest.expect
@@ -1,0 +1,186 @@
+[
+    [
+        InlayHint {
+            position: Position {
+                line: 27,
+                character: 9,
+            },
+            label: LabelParts(
+                [
+                    InlayHintLabelPart {
+                        value: ": ",
+                        tooltip: None,
+                        location: None,
+                        command: None,
+                    },
+                    InlayHintLabelPart {
+                        value: "i64",
+                        tooltip: Some(
+                            MarkupContent(
+                                MarkupContent {
+                                    kind: Markdown,
+                                    value: "primitive",
+                                },
+                            ),
+                        ),
+                        location: None,
+                        command: None,
+                    },
+                ],
+            ),
+            kind: Some(
+                Type,
+            ),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        },
+        InlayHint {
+            position: Position {
+                line: 46,
+                character: 10,
+            },
+            label: LabelParts(
+                [
+                    InlayHintLabelPart {
+                        value: ": ",
+                        tooltip: None,
+                        location: None,
+                        command: None,
+                    },
+                    InlayHintLabelPart {
+                        value: "testSt2",
+                        tooltip: Some(
+                            MarkupContent(
+                                MarkupContent {
+                                    kind: Markdown,
+                                    value: "",
+                                },
+                            ),
+                        ),
+                        location: None,
+                        command: None,
+                    },
+                ],
+            ),
+            kind: Some(
+                Type,
+            ),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        },
+        InlayHint {
+            position: Position {
+                line: 48,
+                character: 9,
+            },
+            label: LabelParts(
+                [
+                    InlayHintLabelPart {
+                        value: ": ",
+                        tooltip: None,
+                        location: None,
+                        command: None,
+                    },
+                    InlayHintLabelPart {
+                        value: "bool",
+                        tooltip: Some(
+                            MarkupContent(
+                                MarkupContent {
+                                    kind: Markdown,
+                                    value: "primitive",
+                                },
+                            ),
+                        ),
+                        location: None,
+                        command: None,
+                    },
+                ],
+            ),
+            kind: Some(
+                Type,
+            ),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        },
+        InlayHint {
+            position: Position {
+                line: 51,
+                character: 9,
+            },
+            label: String(
+                "args:",
+            ),
+            kind: Some(
+                Type,
+            ),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        },
+        InlayHint {
+            position: Position {
+                line: 51,
+                character: 23,
+            },
+            label: String(
+                "b:",
+            ),
+            kind: Some(
+                Type,
+            ),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        },
+        InlayHint {
+            position: Position {
+                line: 55,
+                character: 8,
+            },
+            label: LabelParts(
+                [
+                    InlayHintLabelPart {
+                        value: ": ",
+                        tooltip: None,
+                        location: None,
+                        command: None,
+                    },
+                    InlayHintLabelPart {
+                        value: "*i64",
+                        tooltip: Some(
+                            MarkupContent(
+                                MarkupContent {
+                                    kind: Markdown,
+                                    value: "pointer",
+                                },
+                            ),
+                        ),
+                        location: None,
+                        command: None,
+                    },
+                ],
+            ),
+            kind: Some(
+                Type,
+            ),
+            text_edits: None,
+            tooltip: None,
+            padding_left: None,
+            padding_right: None,
+            data: None,
+        },
+    ],
+]

--- a/src/ast/expects/trait_diag.pi.expect
+++ b/src/ast/expects/trait_diag.pi.expect
@@ -31,14 +31,61 @@
             source: None,
             range: Range {
                 start: Pos {
-                    line: 173,
+                    line: 174,
                     column: 15,
-                    offset: 2475,
+                    offset: 2526,
                 },
                 end: Pos {
-                    line: 173,
+                    line: 174,
                     column: 17,
-                    offset: 2477,
+                    offset: 2528,
+                },
+            },
+        },
+    },
+    PLDiag {
+        raw: PLDiagRaw {
+            code: Err(
+                TYPE_MISMATCH,
+            ),
+            help: None,
+            labels: [
+                PLLabel {
+                    file: u!(""),
+                    txt: Some(
+                        (
+                            u!("expected type {}, real type {}"),
+                            [
+                                u!("**A"),
+                                u!("TestTrait"),
+                            ],
+                        ),
+                    ),
+                    range: Range {
+                        start: Pos {
+                            line: 125,
+                            column: 5,
+                            offset: 1875,
+                        },
+                        end: Pos {
+                            line: 125,
+                            column: 7,
+                            offset: 1877,
+                        },
+                    },
+                },
+            ],
+            source: None,
+            range: Range {
+                start: Pos {
+                    line: 125,
+                    column: 5,
+                    offset: 1875,
+                },
+                end: Pos {
+                    line: 125,
+                    column: 7,
+                    offset: 1877,
                 },
             },
         },
@@ -200,14 +247,14 @@
                     ),
                     range: Range {
                         start: Pos {
-                            line: 177,
+                            line: 178,
                             column: 6,
-                            offset: 2488,
+                            offset: 2539,
                         },
                         end: Pos {
-                            line: 177,
+                            line: 178,
                             column: 7,
-                            offset: 2489,
+                            offset: 2540,
                         },
                     },
                 },
@@ -215,14 +262,14 @@
             source: None,
             range: Range {
                 start: Pos {
-                    line: 177,
+                    line: 178,
                     column: 6,
-                    offset: 2488,
+                    offset: 2539,
                 },
                 end: Pos {
-                    line: 177,
+                    line: 178,
                     column: 7,
-                    offset: 2489,
+                    offset: 2540,
                 },
             },
         },
@@ -323,12 +370,12 @@
                         start: Pos {
                             line: 105,
                             column: 21,
-                            offset: 1334,
+                            offset: 1373,
                         },
                         end: Pos {
                             line: 105,
                             column: 21,
-                            offset: 1334,
+                            offset: 1373,
                         },
                     },
                 },
@@ -346,12 +393,12 @@
                         start: Pos {
                             line: 105,
                             column: 20,
-                            offset: 1333,
+                            offset: 1372,
                         },
                         end: Pos {
                             line: 105,
                             column: 21,
-                            offset: 1334,
+                            offset: 1373,
                         },
                     },
                 },
@@ -369,12 +416,12 @@
                         start: Pos {
                             line: 105,
                             column: 14,
-                            offset: 1327,
+                            offset: 1366,
                         },
                         end: Pos {
                             line: 105,
                             column: 16,
-                            offset: 1329,
+                            offset: 1368,
                         },
                     },
                 },
@@ -384,12 +431,12 @@
                 start: Pos {
                     line: 105,
                     column: 14,
-                    offset: 1327,
+                    offset: 1366,
                 },
                 end: Pos {
                     line: 105,
                     column: 21,
-                    offset: 1334,
+                    offset: 1373,
                 },
             },
         },
@@ -485,12 +532,12 @@
                         start: Pos {
                             line: 124,
                             column: 9,
-                            offset: 1811,
+                            offset: 1850,
                         },
                         end: Pos {
                             line: 124,
                             column: 17,
-                            offset: 1819,
+                            offset: 1858,
                         },
                     },
                 },
@@ -500,12 +547,12 @@
                 start: Pos {
                     line: 124,
                     column: 9,
-                    offset: 1811,
+                    offset: 1850,
                 },
                 end: Pos {
                     line: 124,
                     column: 17,
-                    offset: 1819,
+                    offset: 1858,
                 },
             },
         },
@@ -531,12 +578,12 @@
                         start: Pos {
                             line: 124,
                             column: 9,
-                            offset: 1811,
+                            offset: 1850,
                         },
                         end: Pos {
                             line: 124,
                             column: 17,
-                            offset: 1819,
+                            offset: 1858,
                         },
                     },
                 },
@@ -546,12 +593,12 @@
                 start: Pos {
                     line: 124,
                     column: 9,
-                    offset: 1811,
+                    offset: 1850,
                 },
                 end: Pos {
                     line: 124,
                     column: 17,
-                    offset: 1819,
+                    offset: 1858,
                 },
             },
         },

--- a/src/ast/node/cast.rs
+++ b/src/ast/node/cast.rs
@@ -142,7 +142,7 @@ impl<'a, 'ctx> Ctx<'a> {
                         .add_to_ctx(self))
                 }
             }
-            (PLType::Trait(t), target_ty) => {
+            (PLType::Trait(t), target_ty) if !matches!(target_ty, PLType::Trait(_)) => {
                 if node.tail.is_none() {
                     let pos = node.target_type.range().end;
                     let end_range = Range {

--- a/src/ast/node/types.rs
+++ b/src/ast/node/types.rs
@@ -696,7 +696,6 @@ impl Node for StructInitNode {
             TypeNodeEnum::Basic(b) => b.get_origin_type_with_infer(ctx, builder)?,
             _ => unreachable!(),
         };
-        ctx.set_if_refs_tp(pltype.clone(), self.typename.range());
         let mut sttype = match &*pltype.clone().borrow() {
             PLType::Struct(s) => s.clone(),
             _ => {
@@ -706,7 +705,6 @@ impl Node for StructInitNode {
                     .add_to_ctx(ctx))
             }
         };
-        ctx.send_if_go_to_def(self.typename.range(), sttype.range, sttype.path);
         // let mut field_init_values = vec![];
         let mut idx = 0;
         ctx.save_if_comment_doc_hover(self.typename.range(), Some(sttype.doc.clone()));

--- a/src/ast/test.rs
+++ b/src/ast/test.rs
@@ -6,9 +6,7 @@ use std::{
 };
 
 use expect_test::expect_file;
-use lsp_types::{
-    CompletionItemKind, GotoDefinitionResponse, HoverContents, InlayHintLabel, MarkedString,
-};
+use lsp_types::{CompletionItemKind, GotoDefinitionResponse, HoverContents, MarkedString};
 use rustc_hash::FxHashMap;
 use salsa::{accumulator::Accumulator, storage::HasJar};
 use wait_timeout::ChildExt;
@@ -230,12 +228,9 @@ fn test_hint() {
         ActionType::Hint,
         "test/lsp/test_completion.pi",
     );
-    assert!(!hints.is_empty());
-    assert!(!hints[0].is_empty());
-    if let InlayHintLabel::LabelParts(p) = &hints[0][0].label {
-        assert_eq!(p[0].value, ": ".to_string());
-        assert_eq!(p[1].value, "i64".to_string());
-    }
+
+    let expect = expect_file!["expects/hinttest.expect"];
+    expect.assert_eq(&format!("{:#?}", hints));
 }
 fn new_diag_range(sl: u32, sc: u32, el: u32, ec: u32) -> lsp_types::Range {
     lsp_types::Range {

--- a/src/nomparser/identifier.rs
+++ b/src/nomparser/identifier.rs
@@ -46,20 +46,22 @@ pub fn extern_identifier(input: Span) -> IResult<Span, Box<NodeEnum>> {
             opt(tag_token_symbol(TokenType::COLON)),        // 容忍未写完的语句
         )),
         |(mut identifier_with_namespace, opt, opt2)| {
-            let id = identifier_with_namespace.pop().unwrap();
+            let id = identifier_with_namespace.first().unwrap();
+            let lastid = identifier_with_namespace.last().unwrap().clone();
 
-            let mut range = id.range();
+            let mut range = id.range().start.to(lastid.range().end);
             if let Some(opt) = opt {
                 range = range.start.to(opt.1.end);
             }
             if let Some(opt2) = opt2 {
                 range = range.start.to(opt2.1.end);
             }
+            identifier_with_namespace.pop();
             res_enum(
                 ExternIdNode {
                     // after poping, only namespaces are left
                     namespace: identifier_with_namespace,
-                    id,
+                    id: lastid,
                     range,
                     complete: opt.is_none() && opt2.is_none(),
                     singlecolon: opt2.is_some(),

--- a/src/nomparser/statement.rs
+++ b/src/nomparser/statement.rs
@@ -197,13 +197,18 @@ pub fn assignment(input: Span) -> IResult<Span, Box<NodeEnum>> {
     delspace(map_res(
         tuple((
             alt((
-                map(pointer_exp, AssignVar::Pointer),
-                map(deconstruct, AssignVar::Raw),
+                terminated(
+                    map(deconstruct, AssignVar::Raw),
+                    tag_token_symbol_ex(TokenType::ASSIGN),
+                ),
+                terminated(
+                    map(pointer_exp, AssignVar::Pointer),
+                    tag_token_symbol_ex(TokenType::ASSIGN),
+                ),
             )),
-            tag_token_symbol(TokenType::ASSIGN),
             general_exp,
         )),
-        |(left, _op, right)| {
+        |(left, right)| {
             let range = left.range().start.to(right.range().end);
             res_enum(
                 AssignNode {

--- a/test/lsp/test_completion.pi
+++ b/test/lsp/test_completion.pi
@@ -41,12 +41,15 @@ struct a {
 use test::mod2;
 use test::trait1;
 
+use core::panic;
+
 fn traitname() void {
     let st = trait1::testSt2{};
     let a:trait1::TestTrait = st;
     let d = st.a;
     a.name();
     trait1::new();
+    name(panic::assert(true));
     return;
 }
 

--- a/test/lsp_diag/trait_diag.pi
+++ b/test/lsp_diag/trait_diag.pi
@@ -99,9 +99,9 @@ pub fn test_trait() void {
     let b:generic_trait1<f32> = a;
     b.name1(1);
     let dd: TestTrait;
-    dd = x;
-    dd = y;
-    dd = z;
+    dd = x as TestTrait;
+    dd = y as TestTrait;
+    dd = z as TestTrait;
     let _c = dd as A;
     let _cc = dd as B<i64>?;
     let _ccc = dd as C<i64>!;
@@ -122,6 +122,7 @@ pub fn test_trait() void {
     fn_with_trait(y);
     fn_with_trait(y);
     let hashtest:Hash = "a";
+    dd = z;
     return;
 }
 

--- a/test/test/deconstruct.pi
+++ b/test/test/deconstruct.pi
@@ -26,6 +26,12 @@ pub fn test_deconstruct() void {
         aa: false,
         cc: (3, 4)
     };
+    let (d1,d2) = (1,2);
+    (d1,d2) = (3,4);
+    panic::assert(d1 == 3);
+    panic::assert(d2 == 4);
+
+    
     panic::assert(!aa);
     panic::assert(cc1 + cc2 == 3 + 4);
     return;

--- a/test/test/multi_trait.pi
+++ b/test/test/multi_trait.pi
@@ -14,7 +14,7 @@ trait C: A+B {
 pub fn test_multi_trait() void {
     let t = test_struct{};
     let c: C;
-    c = t;
+    c = t as C;
     let d = c is test_struct;
     panic::assert(d);
     let _casted_0 = c as test_struct!;
@@ -29,7 +29,7 @@ pub fn test_multi_trait() void {
     panic::assert(x);
     panic::assert(y == 1000);
     panic::assert(trait_with_generic(t) == 1000);
-    cc = c;
+    cc = c as B;
     dd = cc is test_struct;
     panic::assert(dd);
     y = cc.b();

--- a/test/test/simple.pi
+++ b/test/test/simple.pi
@@ -14,7 +14,7 @@ pub fn test_primitives() void {
     testf32 = testf32 + 1.2;
     let utest: u8 = 1;
     utest = utest + 2;
-    test = 127;
+    test = 127 as i8;
     panic::assert(test == 0x7f);
     panic::assert(test == 0o177);
     panic::assert(test == 0b0111_1111);

--- a/test/test/traits.pi
+++ b/test/test/traits.pi
@@ -82,9 +82,9 @@ pub fn test_trait() void {
     let b:generic_trait1<i64> = a;
     b.name1(1);
     let dd: TestTrait;
-    dd = x;
-    dd = y;
-    dd = z;
+    dd = x as TestTrait;
+    dd = y as TestTrait;
+    dd = z as TestTrait;
     let re = dd.set(100);
     panic::assert(re == 100);
     let re1 = trait_ret().set(1);

--- a/test/test/union.pi
+++ b/test/test/union.pi
@@ -5,7 +5,7 @@ type D = *i32 | f64;
 pub fn test_union() i64 {
     let g: Option<i64> = None{};
     panic::assert(g is None);
-    g = 1 as i64;
+    g = 1 as Option<i64>;
     let a: i128 = 1;
     let b: f32 = 1.0;
     let c: A<i128> = a;
@@ -19,9 +19,9 @@ pub fn test_union() i64 {
     let i = h as i128!;
     panic::assert(i == 1);
     let d = c;
-    d = b;
+    d = b as A<i128>;
     let e = a as f32;
-    e = 100.1;
+    e = 100.1 as f32;
     let f = e as i64;
     panic::assert(f == 100);
     let aa: B<i128> = d;
@@ -50,7 +50,7 @@ fn test_ret_union() Option<i64> {
 impl<T> A<T> {
     fn name() void {
         let f = (*self) as f32!;
-        f = 100.0;
+        f = 100.0 as f32;
         return;
     }
 
@@ -59,7 +59,7 @@ impl<T> A<T> {
 type Name = i32 | i64;
 fn generic<R>(a: Option<R>) void {
     let c = a as R!;
-    a = c;
+    a = c as Option<R>;
     return;
 }
 


### PR DESCRIPTION
Previously, inlay hint of function params may occur in wierd positions like: `func(namespace::{hint}fninner())`, this problem is oriented in the broken range infomation we stored during parser step. This commit fixed this issue, and the wrong def jump issue as well.